### PR TITLE
feat: add skills testing for Claude Code and OpenAI Codex

### DIFF
--- a/evalview/skills/__init__.py
+++ b/evalview/skills/__init__.py
@@ -1,0 +1,37 @@
+"""Skills testing module for EvalView.
+
+This module provides tools for parsing, validating, and testing
+Claude Code skills and MCP servers.
+"""
+
+from evalview.skills.types import (
+    Skill,
+    SkillMetadata,
+    SkillValidationResult,
+    SkillValidationError,
+    SkillTestSuite,
+    SkillTest,
+    SkillTestResult,
+    SkillTestSuiteResult,
+)
+from evalview.skills.parser import SkillParser
+from evalview.skills.validator import SkillValidator
+from evalview.skills.runner import SkillRunner
+
+__all__ = [
+    # Types
+    "Skill",
+    "SkillMetadata",
+    "SkillValidationResult",
+    "SkillValidationError",
+    "SkillTestSuite",
+    "SkillTest",
+    "SkillTestResult",
+    "SkillTestSuiteResult",
+    # Parser
+    "SkillParser",
+    # Validator
+    "SkillValidator",
+    # Runner
+    "SkillRunner",
+]

--- a/evalview/skills/parser.py
+++ b/evalview/skills/parser.py
@@ -1,0 +1,219 @@
+"""SKILL.md file parser."""
+
+import re
+from pathlib import Path
+from typing import Optional, Tuple, Dict, Any
+import yaml
+
+from evalview.skills.types import (
+    Skill,
+    SkillMetadata,
+    SkillValidationError,
+    SkillSeverity,
+)
+
+
+class SkillParseError(Exception):
+    """Raised when a skill file cannot be parsed."""
+
+    def __init__(self, message: str, errors: list = None):
+        super().__init__(message)
+        self.errors = errors or []
+
+
+class SkillParser:
+    """Parser for SKILL.md files.
+
+    SKILL.md files have the format:
+    ```
+    ---
+    name: my-skill
+    description: What this skill does
+    ---
+
+    # Instructions
+
+    Markdown content here...
+    ```
+    """
+
+    # Regex to match YAML frontmatter
+    FRONTMATTER_PATTERN = re.compile(
+        r"^---\s*\n(.*?)\n---\s*\n?",
+        re.DOTALL | re.MULTILINE,
+    )
+
+    @classmethod
+    def parse_file(cls, file_path: str) -> Skill:
+        """
+        Parse a SKILL.md file.
+
+        Args:
+            file_path: Path to the SKILL.md file
+
+        Returns:
+            Parsed Skill object
+
+        Raises:
+            SkillParseError: If the file cannot be parsed
+            FileNotFoundError: If the file doesn't exist
+        """
+        path = Path(file_path)
+
+        if not path.exists():
+            raise FileNotFoundError(f"Skill file not found: {file_path}")
+
+        if not path.is_file():
+            raise SkillParseError(f"Path is not a file: {file_path}")
+
+        content = path.read_text(encoding="utf-8")
+        return cls.parse_content(content, file_path=str(path.absolute()))
+
+    @classmethod
+    def parse_content(cls, content: str, file_path: Optional[str] = None) -> Skill:
+        """
+        Parse SKILL.md content from a string.
+
+        Args:
+            content: Raw SKILL.md content
+            file_path: Optional path for error messages
+
+        Returns:
+            Parsed Skill object
+
+        Raises:
+            SkillParseError: If the content cannot be parsed
+        """
+        errors = []
+
+        # Check for empty content
+        if not content or not content.strip():
+            raise SkillParseError(
+                "Skill file is empty",
+                errors=[
+                    SkillValidationError(
+                        code="EMPTY_FILE",
+                        message="SKILL.md file is empty",
+                        severity=SkillSeverity.ERROR,
+                    )
+                ],
+            )
+
+        # Extract frontmatter
+        frontmatter_dict, instructions, parse_errors = cls._extract_frontmatter(content)
+        errors.extend(parse_errors)
+
+        if errors:
+            raise SkillParseError(
+                f"Failed to parse skill: {errors[0].message}",
+                errors=errors,
+            )
+
+        # Parse metadata
+        try:
+            metadata = SkillMetadata(**frontmatter_dict)
+        except Exception as e:
+            raise SkillParseError(
+                f"Invalid metadata: {str(e)}",
+                errors=[
+                    SkillValidationError(
+                        code="INVALID_METADATA",
+                        message=str(e),
+                        severity=SkillSeverity.ERROR,
+                    )
+                ],
+            )
+
+        return Skill(
+            metadata=metadata,
+            instructions=instructions,
+            raw_content=content,
+            file_path=file_path,
+        )
+
+    @classmethod
+    def _extract_frontmatter(
+        cls, content: str
+    ) -> Tuple[Dict[str, Any], str, list]:
+        """
+        Extract YAML frontmatter and markdown body from content.
+
+        Returns:
+            Tuple of (frontmatter_dict, markdown_body, errors)
+        """
+        errors = []
+
+        # Check for frontmatter delimiter
+        if not content.startswith("---"):
+            errors.append(
+                SkillValidationError(
+                    code="MISSING_FRONTMATTER",
+                    message="SKILL.md must start with YAML frontmatter (---)",
+                    severity=SkillSeverity.ERROR,
+                    line=1,
+                    suggestion="Add frontmatter at the start:\n---\nname: my-skill\ndescription: What this skill does\n---",
+                )
+            )
+            return {}, content, errors
+
+        # Extract frontmatter using regex
+        match = cls.FRONTMATTER_PATTERN.match(content)
+        if not match:
+            errors.append(
+                SkillValidationError(
+                    code="INVALID_FRONTMATTER",
+                    message="Could not parse YAML frontmatter. Make sure it's enclosed in --- delimiters.",
+                    severity=SkillSeverity.ERROR,
+                    line=1,
+                    suggestion="Ensure frontmatter is properly formatted:\n---\nname: my-skill\ndescription: What this skill does\n---",
+                )
+            )
+            return {}, content, errors
+
+        frontmatter_yaml = match.group(1)
+        markdown_body = content[match.end():].strip()
+
+        # Parse YAML
+        try:
+            frontmatter_dict = yaml.safe_load(frontmatter_yaml) or {}
+        except yaml.YAMLError as e:
+            errors.append(
+                SkillValidationError(
+                    code="YAML_ERROR",
+                    message=f"Invalid YAML in frontmatter: {str(e)}",
+                    severity=SkillSeverity.ERROR,
+                    suggestion="Check your YAML syntax. Common issues: missing quotes around special characters, incorrect indentation.",
+                )
+            )
+            return {}, markdown_body, errors
+
+        if not isinstance(frontmatter_dict, dict):
+            errors.append(
+                SkillValidationError(
+                    code="INVALID_FRONTMATTER_TYPE",
+                    message="Frontmatter must be a YAML dictionary/object",
+                    severity=SkillSeverity.ERROR,
+                )
+            )
+            return {}, markdown_body, errors
+
+        return frontmatter_dict, markdown_body, errors
+
+    @classmethod
+    def find_skills(cls, directory: str, recursive: bool = True) -> list:
+        """
+        Find all SKILL.md files in a directory.
+
+        Args:
+            directory: Directory to search
+            recursive: Whether to search subdirectories
+
+        Returns:
+            List of paths to SKILL.md files
+        """
+        path = Path(directory)
+        if not path.exists():
+            return []
+
+        pattern = "**/SKILL.md" if recursive else "SKILL.md"
+        return [str(p) for p in path.glob(pattern)]

--- a/evalview/skills/runner.py
+++ b/evalview/skills/runner.py
@@ -1,0 +1,254 @@
+"""Skill test runner - executes skills against Claude."""
+
+import time
+from pathlib import Path
+from typing import Optional
+import yaml
+
+from evalview.skills.types import (
+    Skill,
+    SkillTestSuite,
+    SkillTest,
+    SkillTestResult,
+    SkillTestSuiteResult,
+    SkillExpectedBehavior,
+)
+from evalview.skills.parser import SkillParser
+
+
+class SkillRunner:
+    """Runs skill tests against Claude API.
+
+    Loads a skill, sends test queries, and evaluates responses.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: str = "claude-sonnet-4-20250514",
+    ):
+        """
+        Initialize the skill runner.
+
+        Args:
+            api_key: Anthropic API key (or uses ANTHROPIC_API_KEY env var)
+            model: Model to use for testing
+        """
+        import os
+
+        self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Anthropic API key required. Set ANTHROPIC_API_KEY env var or pass api_key."
+            )
+        self.model = model
+        self._client = None
+
+    @property
+    def client(self):
+        """Lazy-load Anthropic client."""
+        if self._client is None:
+            try:
+                import anthropic
+                self._client = anthropic.Anthropic(api_key=self.api_key)
+            except ImportError:
+                raise ImportError(
+                    "anthropic package required. Install with: pip install anthropic"
+                )
+        return self._client
+
+    def load_test_suite(self, yaml_path: str) -> SkillTestSuite:
+        """Load a test suite from YAML file."""
+        path = Path(yaml_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Test suite not found: {yaml_path}")
+
+        with open(path) as f:
+            data = yaml.safe_load(f)
+
+        return SkillTestSuite(**data)
+
+    def run_suite(self, suite: SkillTestSuite) -> SkillTestSuiteResult:
+        """
+        Run all tests in a test suite.
+
+        Args:
+            suite: The test suite to run
+
+        Returns:
+            SkillTestSuiteResult with all results
+        """
+        # Load the skill
+        skill = SkillParser.parse_file(suite.skill)
+
+        # Run each test
+        results = []
+        for test in suite.tests:
+            result = self.run_test(skill, test, model=suite.model)
+            results.append(result)
+
+        # Calculate stats
+        passed_tests = sum(1 for r in results if r.passed)
+        failed_tests = len(results) - passed_tests
+        pass_rate = passed_tests / len(results) if results else 0.0
+
+        total_latency = sum(r.latency_ms for r in results)
+        total_tokens = sum(r.input_tokens + r.output_tokens for r in results)
+
+        return SkillTestSuiteResult(
+            suite_name=suite.name,
+            skill_name=skill.metadata.name,
+            passed=pass_rate >= suite.min_pass_rate,
+            total_tests=len(results),
+            passed_tests=passed_tests,
+            failed_tests=failed_tests,
+            pass_rate=pass_rate,
+            results=results,
+            total_latency_ms=total_latency,
+            avg_latency_ms=total_latency / len(results) if results else 0.0,
+            total_tokens=total_tokens,
+        )
+
+    def run_test(
+        self,
+        skill: Skill,
+        test: SkillTest,
+        model: Optional[str] = None,
+    ) -> SkillTestResult:
+        """
+        Run a single test against a skill.
+
+        Args:
+            skill: The loaded skill
+            test: The test to run
+            model: Model override
+
+        Returns:
+            SkillTestResult
+        """
+        model = model or self.model
+
+        # Build system prompt with skill instructions
+        system_prompt = self._build_system_prompt(skill)
+
+        # Call Claude
+        start_time = time.time()
+        try:
+            response = self.client.messages.create(
+                model=model,
+                max_tokens=4096,
+                system=system_prompt,
+                messages=[{"role": "user", "content": test.input}],
+            )
+            latency_ms = (time.time() - start_time) * 1000
+
+            output = response.content[0].text
+            input_tokens = response.usage.input_tokens
+            output_tokens = response.usage.output_tokens
+            error = None
+
+        except Exception as e:
+            latency_ms = (time.time() - start_time) * 1000
+            output = ""
+            input_tokens = 0
+            output_tokens = 0
+            error = str(e)
+
+        # Evaluate the response
+        evaluation = self._evaluate_response(output, test.expected)
+
+        return SkillTestResult(
+            test_name=test.name,
+            passed=evaluation["passed"] and error is None,
+            score=evaluation["score"],
+            input_query=test.input,
+            output=output,
+            contains_passed=evaluation["contains_passed"],
+            contains_failed=evaluation["contains_failed"],
+            not_contains_passed=evaluation["not_contains_passed"],
+            not_contains_failed=evaluation["not_contains_failed"],
+            latency_ms=latency_ms,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            error=error,
+        )
+
+    def _build_system_prompt(self, skill: Skill) -> str:
+        """Build system prompt with skill loaded."""
+        return f"""You are Claude, an AI assistant with the following skill loaded:
+
+# Skill: {skill.metadata.name}
+
+{skill.metadata.description}
+
+## Instructions
+
+{skill.instructions}
+
+---
+
+Follow the skill instructions above when responding to user queries.
+"""
+
+    def _evaluate_response(
+        self,
+        output: str,
+        expected: SkillExpectedBehavior,
+    ) -> dict:
+        """
+        Evaluate a response against expected behavior.
+
+        Returns dict with: passed, score, contains_passed/failed, not_contains_passed/failed
+        """
+        output_lower = output.lower()
+        total_checks = 0
+        passed_checks = 0
+
+        contains_passed = []
+        contains_failed = []
+        not_contains_passed = []
+        not_contains_failed = []
+
+        # Check output_contains
+        if expected.output_contains:
+            for phrase in expected.output_contains:
+                total_checks += 1
+                if phrase.lower() in output_lower:
+                    passed_checks += 1
+                    contains_passed.append(phrase)
+                else:
+                    contains_failed.append(phrase)
+
+        # Check output_not_contains
+        if expected.output_not_contains:
+            for phrase in expected.output_not_contains:
+                total_checks += 1
+                if phrase.lower() not in output_lower:
+                    passed_checks += 1
+                    not_contains_passed.append(phrase)
+                else:
+                    not_contains_failed.append(phrase)
+
+        # Check max_length
+        if expected.max_length:
+            total_checks += 1
+            if len(output) <= expected.max_length:
+                passed_checks += 1
+
+        # Calculate score
+        if total_checks == 0:
+            # No checks defined, pass by default
+            score = 100.0
+            passed = True
+        else:
+            score = (passed_checks / total_checks) * 100
+            passed = len(contains_failed) == 0 and len(not_contains_failed) == 0
+
+        return {
+            "passed": passed,
+            "score": score,
+            "contains_passed": contains_passed,
+            "contains_failed": contains_failed,
+            "not_contains_passed": not_contains_passed,
+            "not_contains_failed": not_contains_failed,
+        }

--- a/evalview/skills/types.py
+++ b/evalview/skills/types.py
@@ -1,0 +1,225 @@
+"""Type definitions for skills testing."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Optional, List, Dict
+from pydantic import BaseModel, Field, field_validator
+
+
+class SkillSeverity(str, Enum):
+    """Severity level for validation errors."""
+
+    ERROR = "error"  # Must fix - skill won't work
+    WARNING = "warning"  # Should fix - may cause issues
+    INFO = "info"  # Suggestion for improvement
+
+
+class SkillValidationError(BaseModel):
+    """A single validation error or warning."""
+
+    code: str = Field(description="Error code (e.g., 'MISSING_NAME', 'INVALID_TRIGGER')")
+    message: str = Field(description="Human-readable error message")
+    severity: SkillSeverity = Field(default=SkillSeverity.ERROR)
+    line: Optional[int] = Field(default=None, description="Line number if applicable")
+    suggestion: Optional[str] = Field(default=None, description="How to fix this issue")
+
+
+class SkillMetadata(BaseModel):
+    """Metadata from SKILL.md frontmatter."""
+
+    # Required fields
+    name: str = Field(description="Unique identifier for the skill (lowercase, hyphens)")
+    description: str = Field(description="What the skill does and when to use it")
+
+    # Optional fields (based on extended spec)
+    version: Optional[str] = Field(default=None, description="Skill version")
+    author: Optional[str] = Field(default=None, description="Skill author")
+    triggers: Optional[List[str]] = Field(default=None, description="Keywords that activate the skill")
+    tools: Optional[List[str]] = Field(default=None, description="Tools this skill uses")
+    model_requirements: Optional[List[str]] = Field(default=None, description="Required model capabilities")
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def validate_name(cls, v):
+        """Validate skill name format."""
+        if not v:
+            raise ValueError("Skill name is required")
+        if not isinstance(v, str):
+            raise ValueError("Skill name must be a string")
+        # Name should be lowercase with hyphens
+        v = str(v).strip()
+        if not v:
+            raise ValueError("Skill name cannot be empty")
+        return v
+
+    @field_validator("description", mode="before")
+    @classmethod
+    def validate_description(cls, v):
+        """Validate skill description."""
+        if not v:
+            raise ValueError("Skill description is required")
+        if not isinstance(v, str):
+            raise ValueError("Skill description must be a string")
+        v = str(v).strip()
+        if not v:
+            raise ValueError("Skill description cannot be empty")
+        if len(v) < 10:
+            raise ValueError("Skill description should be at least 10 characters")
+        return v
+
+
+class Skill(BaseModel):
+    """A parsed Claude Code skill."""
+
+    # Parsed content
+    metadata: SkillMetadata = Field(description="Frontmatter metadata")
+    instructions: str = Field(description="Markdown instructions body")
+    raw_content: str = Field(description="Original file content")
+
+    # File info
+    file_path: Optional[str] = Field(default=None, description="Path to SKILL.md file")
+
+    # Computed properties
+    @property
+    def token_estimate(self) -> int:
+        """Rough estimate of tokens when skill is loaded."""
+        # ~4 chars per token is a rough estimate
+        return len(self.instructions) // 4
+
+    @property
+    def is_lightweight(self) -> bool:
+        """Check if skill is under the ~5k token recommendation."""
+        return self.token_estimate < 5000
+
+
+class SkillValidationResult(BaseModel):
+    """Result of validating a skill."""
+
+    valid: bool = Field(description="True if no errors (warnings allowed)")
+    skill: Optional[Skill] = Field(default=None, description="Parsed skill if valid")
+    errors: List[SkillValidationError] = Field(default_factory=list)
+    warnings: List[SkillValidationError] = Field(default_factory=list)
+    info: List[SkillValidationError] = Field(default_factory=list)
+
+    @property
+    def has_errors(self) -> bool:
+        """Check if there are any errors."""
+        return len(self.errors) > 0
+
+    @property
+    def has_warnings(self) -> bool:
+        """Check if there are any warnings."""
+        return len(self.warnings) > 0
+
+    @property
+    def total_issues(self) -> int:
+        """Total number of issues found."""
+        return len(self.errors) + len(self.warnings) + len(self.info)
+
+
+# ============================================================================
+# Skill Test Types
+# ============================================================================
+
+
+class SkillTestInput(BaseModel):
+    """Input for a skill test case."""
+
+    query: str = Field(description="User query that should trigger the skill")
+    context: Optional[Dict[str, Any]] = Field(default=None, description="Additional context")
+
+
+class SkillExpectedBehavior(BaseModel):
+    """Expected behavior when skill is invoked."""
+
+    should_activate: bool = Field(default=True, description="Should this query activate the skill?")
+    output_contains: Optional[List[str]] = Field(default=None, description="Strings that should appear in output")
+    output_not_contains: Optional[List[str]] = Field(default=None, description="Strings that should NOT appear")
+    tone: Optional[str] = Field(default=None, description="Expected tone: professional, casual, technical, etc.")
+    max_length: Optional[int] = Field(default=None, description="Maximum response length in characters")
+
+
+class SkillTest(BaseModel):
+    """A single test within a skill test suite."""
+
+    __test__ = False  # Tell pytest this is not a test class
+
+    name: str = Field(description="Test name")
+    description: Optional[str] = Field(default=None)
+    input: str = Field(description="User query to test")
+    expected: SkillExpectedBehavior
+
+
+class SkillTestSuite(BaseModel):
+    """A complete test suite for a skill (loaded from YAML)."""
+
+    __test__ = False  # Tell pytest this is not a test class
+
+    name: str = Field(description="Test suite name")
+    description: Optional[str] = Field(default=None)
+    skill: str = Field(description="Path to SKILL.md file")
+
+    # Optional config
+    model: str = Field(default="claude-sonnet-4-20250514", description="Model to use")
+
+    # Test cases
+    tests: List[SkillTest] = Field(description="List of test cases")
+
+    # Thresholds
+    min_pass_rate: float = Field(default=0.8, ge=0, le=1, description="Minimum pass rate (0-1)")
+
+
+class SkillTestResult(BaseModel):
+    """Result of running a single skill test."""
+
+    __test__ = False  # Tell pytest this is not a test class
+
+    test_name: str
+    passed: bool
+    score: float = Field(ge=0, le=100)
+
+    # What happened
+    input_query: str
+    output: str
+
+    # Evaluation breakdown
+    contains_passed: List[str] = Field(default_factory=list)
+    contains_failed: List[str] = Field(default_factory=list)
+    not_contains_passed: List[str] = Field(default_factory=list)
+    not_contains_failed: List[str] = Field(default_factory=list)
+
+    # Metrics
+    latency_ms: float = 0.0
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    # Error if any
+    error: Optional[str] = None
+
+    timestamp: datetime = Field(default_factory=datetime.now)
+
+
+class SkillTestSuiteResult(BaseModel):
+    """Result of running a complete skill test suite."""
+
+    __test__ = False  # Tell pytest this is not a test class
+
+    suite_name: str
+    skill_name: str
+    passed: bool
+
+    # Stats
+    total_tests: int
+    passed_tests: int
+    failed_tests: int
+    pass_rate: float
+
+    # Individual results
+    results: List[SkillTestResult] = Field(default_factory=list)
+
+    # Aggregate metrics
+    total_latency_ms: float = 0.0
+    avg_latency_ms: float = 0.0
+    total_tokens: int = 0
+
+    timestamp: datetime = Field(default_factory=datetime.now)

--- a/evalview/skills/validator.py
+++ b/evalview/skills/validator.py
@@ -1,0 +1,413 @@
+"""Skill validator for comprehensive validation checks."""
+
+import re
+from pathlib import Path
+from typing import List, Optional
+
+from evalview.skills.types import (
+    Skill,
+    SkillValidationResult,
+    SkillValidationError,
+    SkillSeverity,
+)
+from evalview.skills.parser import SkillParser, SkillParseError
+
+
+class SkillValidator:
+    """Comprehensive validator for Claude Code skills.
+
+    Performs multiple validation checks:
+    - Structure: Frontmatter format, required fields
+    - Naming: Valid skill names, no conflicts
+    - Content: Instructions quality, token size
+    - Policy: No prohibited patterns, safe instructions
+    - Best practices: Guidelines adherence
+    """
+
+    # Token limit recommendations
+    METADATA_TOKEN_ESTIMATE = 100  # ~100 tokens for metadata scanning
+    MAX_RECOMMENDED_TOKENS = 5000  # Skills should be under 5k tokens when loaded
+
+    # Naming rules
+    NAME_PATTERN = re.compile(r"^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$")
+
+    # Prohibited patterns in instructions (policy compliance)
+    PROHIBITED_PATTERNS = [
+        (r"\bignore\s+(all\s+)?previous\s+instructions?\b", "Prompt injection attempt"),
+        (r"\bforget\s+(everything|all)\b", "Prompt injection attempt"),
+        (r"\byou\s+are\s+now\b", "Role hijacking attempt"),
+        (r"\bact\s+as\s+(if\s+you\s+are\s+)?a?\s*(different|new)\b", "Role hijacking attempt"),
+        (r"\bexecute\s+(arbitrary|any)\s+code\b", "Unsafe code execution"),
+        (r"\b(rm\s+-rf|format\s+c:|del\s+/[sq])\b", "Destructive commands"),
+        (r"\b(api[_-]?key|secret[_-]?key|password)\s*[=:]\s*['\"][^'\"]+['\"]", "Hardcoded secrets"),
+    ]
+
+    # Warning patterns (not prohibited but concerning)
+    WARNING_PATTERNS = [
+        (r"\balways\s+trust\b", "Unconditional trust statement"),
+        (r"\bnever\s+question\b", "Blocks critical thinking"),
+        (r"\bno\s+matter\s+what\b", "Overly rigid instruction"),
+        (r"\bbypass\b", "Potential security bypass"),
+    ]
+
+    @classmethod
+    def validate_file(cls, file_path: str) -> SkillValidationResult:
+        """
+        Validate a SKILL.md file.
+
+        Args:
+            file_path: Path to the SKILL.md file
+
+        Returns:
+            SkillValidationResult with validation outcome
+        """
+        errors = []
+        warnings = []
+        info = []
+
+        # Check file exists
+        path = Path(file_path)
+        if not path.exists():
+            return SkillValidationResult(
+                valid=False,
+                errors=[
+                    SkillValidationError(
+                        code="FILE_NOT_FOUND",
+                        message=f"File not found: {file_path}",
+                        severity=SkillSeverity.ERROR,
+                    )
+                ],
+            )
+
+        # Check filename
+        if path.name != "SKILL.md":
+            warnings.append(
+                SkillValidationError(
+                    code="WRONG_FILENAME",
+                    message=f"Expected 'SKILL.md', got '{path.name}'",
+                    severity=SkillSeverity.WARNING,
+                    suggestion="Rename the file to SKILL.md for Claude to recognize it",
+                )
+            )
+
+        # Parse the skill
+        try:
+            skill = SkillParser.parse_file(file_path)
+        except SkillParseError as e:
+            return SkillValidationResult(
+                valid=False,
+                errors=e.errors,
+            )
+        except Exception as e:
+            return SkillValidationResult(
+                valid=False,
+                errors=[
+                    SkillValidationError(
+                        code="PARSE_ERROR",
+                        message=f"Failed to parse skill: {str(e)}",
+                        severity=SkillSeverity.ERROR,
+                    )
+                ],
+            )
+
+        # Run all validations
+        errors.extend(cls._validate_name(skill))
+        errors.extend(cls._validate_description(skill))
+        warnings.extend(cls._validate_instructions(skill))
+        errors.extend(cls._validate_policy_compliance(skill))
+        warnings.extend(cls._check_warning_patterns(skill))
+        info.extend(cls._validate_best_practices(skill))
+
+        # Separate by severity
+        all_issues = errors + warnings + info
+        errors = [e for e in all_issues if e.severity == SkillSeverity.ERROR]
+        warnings = [e for e in all_issues if e.severity == SkillSeverity.WARNING]
+        info = [e for e in all_issues if e.severity == SkillSeverity.INFO]
+
+        return SkillValidationResult(
+            valid=len(errors) == 0,
+            skill=skill if len(errors) == 0 else None,
+            errors=errors,
+            warnings=warnings,
+            info=info,
+        )
+
+    @classmethod
+    def validate_content(cls, content: str) -> SkillValidationResult:
+        """
+        Validate SKILL.md content from a string.
+
+        Args:
+            content: Raw SKILL.md content
+
+        Returns:
+            SkillValidationResult with validation outcome
+        """
+        errors = []
+        warnings = []
+        info = []
+
+        # Parse the skill
+        try:
+            skill = SkillParser.parse_content(content)
+        except SkillParseError as e:
+            return SkillValidationResult(
+                valid=False,
+                errors=e.errors,
+            )
+        except Exception as e:
+            return SkillValidationResult(
+                valid=False,
+                errors=[
+                    SkillValidationError(
+                        code="PARSE_ERROR",
+                        message=f"Failed to parse skill: {str(e)}",
+                        severity=SkillSeverity.ERROR,
+                    )
+                ],
+            )
+
+        # Run all validations
+        errors.extend(cls._validate_name(skill))
+        errors.extend(cls._validate_description(skill))
+        warnings.extend(cls._validate_instructions(skill))
+        errors.extend(cls._validate_policy_compliance(skill))
+        warnings.extend(cls._check_warning_patterns(skill))
+        info.extend(cls._validate_best_practices(skill))
+
+        # Separate by severity
+        all_issues = errors + warnings + info
+        errors = [e for e in all_issues if e.severity == SkillSeverity.ERROR]
+        warnings = [e for e in all_issues if e.severity == SkillSeverity.WARNING]
+        info = [e for e in all_issues if e.severity == SkillSeverity.INFO]
+
+        return SkillValidationResult(
+            valid=len(errors) == 0,
+            skill=skill if len(errors) == 0 else None,
+            errors=errors,
+            warnings=warnings,
+            info=info,
+        )
+
+    @classmethod
+    def _validate_name(cls, skill: Skill) -> List[SkillValidationError]:
+        """Validate skill name format."""
+        errors = []
+        name = skill.metadata.name
+
+        # Check name format (lowercase, hyphens, no underscores)
+        if not cls.NAME_PATTERN.match(name):
+            errors.append(
+                SkillValidationError(
+                    code="INVALID_NAME_FORMAT",
+                    message=f"Invalid skill name format: '{name}'",
+                    severity=SkillSeverity.ERROR,
+                    suggestion="Use lowercase letters, numbers, and hyphens only. Must start with a letter. Example: 'my-skill-name'",
+                )
+            )
+
+        # Check for underscores (common mistake)
+        if "_" in name:
+            errors.append(
+                SkillValidationError(
+                    code="NAME_HAS_UNDERSCORE",
+                    message=f"Skill name contains underscores: '{name}'",
+                    severity=SkillSeverity.ERROR,
+                    suggestion=f"Use hyphens instead: '{name.replace('_', '-')}'",
+                )
+            )
+
+        # Check for uppercase
+        if name != name.lower():
+            errors.append(
+                SkillValidationError(
+                    code="NAME_NOT_LOWERCASE",
+                    message=f"Skill name must be lowercase: '{name}'",
+                    severity=SkillSeverity.ERROR,
+                    suggestion=f"Use: '{name.lower()}'",
+                )
+            )
+
+        # Check name length
+        if len(name) > 50:
+            errors.append(
+                SkillValidationError(
+                    code="NAME_TOO_LONG",
+                    message=f"Skill name is too long ({len(name)} chars, max 50)",
+                    severity=SkillSeverity.WARNING,
+                    suggestion="Use a shorter, more concise name",
+                )
+            )
+
+        return errors
+
+    @classmethod
+    def _validate_description(cls, skill: Skill) -> List[SkillValidationError]:
+        """Validate skill description."""
+        errors = []
+        desc = skill.metadata.description
+
+        # Check minimum length
+        if len(desc) < 20:
+            errors.append(
+                SkillValidationError(
+                    code="DESCRIPTION_TOO_SHORT",
+                    message=f"Description is too short ({len(desc)} chars)",
+                    severity=SkillSeverity.WARNING,
+                    suggestion="Provide a more detailed description of what the skill does and when to use it",
+                )
+            )
+
+        # Check for placeholder text
+        placeholder_patterns = [
+            r"^todo\b",
+            r"^tbd\b",
+            r"^placeholder\b",
+            r"^describe\s+here\b",
+            r"^your\s+description\b",
+        ]
+        for pattern in placeholder_patterns:
+            if re.search(pattern, desc.lower()):
+                errors.append(
+                    SkillValidationError(
+                        code="PLACEHOLDER_DESCRIPTION",
+                        message="Description appears to be a placeholder",
+                        severity=SkillSeverity.ERROR,
+                        suggestion="Replace with an actual description of the skill",
+                    )
+                )
+                break
+
+        return errors
+
+    @classmethod
+    def _validate_instructions(cls, skill: Skill) -> List[SkillValidationError]:
+        """Validate skill instructions."""
+        warnings = []
+        instructions = skill.instructions
+
+        # Check for empty instructions
+        if not instructions.strip():
+            warnings.append(
+                SkillValidationError(
+                    code="EMPTY_INSTRUCTIONS",
+                    message="Skill has no instructions",
+                    severity=SkillSeverity.WARNING,
+                    suggestion="Add markdown instructions below the frontmatter",
+                )
+            )
+            return warnings
+
+        # Check token size
+        if skill.token_estimate > cls.MAX_RECOMMENDED_TOKENS:
+            warnings.append(
+                SkillValidationError(
+                    code="SKILL_TOO_LARGE",
+                    message=f"Skill is ~{skill.token_estimate} tokens (recommended: <{cls.MAX_RECOMMENDED_TOKENS})",
+                    severity=SkillSeverity.WARNING,
+                    suggestion="Consider splitting into multiple skills or reducing instruction length",
+                )
+            )
+
+        # Check for very short instructions
+        if len(instructions) < 50:
+            warnings.append(
+                SkillValidationError(
+                    code="INSTRUCTIONS_TOO_SHORT",
+                    message="Instructions are very short",
+                    severity=SkillSeverity.INFO,
+                    suggestion="Consider adding more detail, examples, or guidelines",
+                )
+            )
+
+        return warnings
+
+    @classmethod
+    def _validate_policy_compliance(cls, skill: Skill) -> List[SkillValidationError]:
+        """Check for prohibited patterns (policy violations)."""
+        errors = []
+        content = skill.raw_content.lower()
+
+        for pattern, description in cls.PROHIBITED_PATTERNS:
+            if re.search(pattern, content, re.IGNORECASE):
+                errors.append(
+                    SkillValidationError(
+                        code="POLICY_VIOLATION",
+                        message=f"Potential policy violation: {description}",
+                        severity=SkillSeverity.ERROR,
+                        suggestion="Remove or rephrase the problematic content",
+                    )
+                )
+
+        return errors
+
+    @classmethod
+    def _check_warning_patterns(cls, skill: Skill) -> List[SkillValidationError]:
+        """Check for warning patterns (not prohibited but concerning)."""
+        warnings = []
+        content = skill.raw_content.lower()
+
+        for pattern, description in cls.WARNING_PATTERNS:
+            if re.search(pattern, content, re.IGNORECASE):
+                warnings.append(
+                    SkillValidationError(
+                        code="CONCERNING_PATTERN",
+                        message=f"Concerning pattern found: {description}",
+                        severity=SkillSeverity.WARNING,
+                        suggestion="Review this instruction to ensure it's appropriate",
+                    )
+                )
+
+        return warnings
+
+    @classmethod
+    def _validate_best_practices(cls, skill: Skill) -> List[SkillValidationError]:
+        """Check best practices (informational suggestions)."""
+        info = []
+        instructions = skill.instructions
+
+        # Check for examples section
+        if not re.search(r"##+\s*examples?\b", instructions, re.IGNORECASE):
+            info.append(
+                SkillValidationError(
+                    code="NO_EXAMPLES",
+                    message="No examples section found",
+                    severity=SkillSeverity.INFO,
+                    suggestion="Adding examples helps Claude understand how to use the skill",
+                )
+            )
+
+        # Check for guidelines section
+        if not re.search(r"##+\s*(guidelines?|rules?)\b", instructions, re.IGNORECASE):
+            info.append(
+                SkillValidationError(
+                    code="NO_GUIDELINES",
+                    message="No guidelines section found",
+                    severity=SkillSeverity.INFO,
+                    suggestion="Adding guidelines helps Claude follow best practices",
+                )
+            )
+
+        return info
+
+    @classmethod
+    def validate_directory(
+        cls, directory: str, recursive: bool = True
+    ) -> dict:
+        """
+        Validate all skills in a directory.
+
+        Args:
+            directory: Directory to search
+            recursive: Whether to search subdirectories
+
+        Returns:
+            Dict mapping file paths to validation results
+        """
+        skill_files = SkillParser.find_skills(directory, recursive)
+        results = {}
+
+        for file_path in skill_files:
+            results[file_path] = cls.validate_file(file_path)
+
+        return results

--- a/examples/skills/test-skill/SKILL.md
+++ b/examples/skills/test-skill/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: code-reviewer
+description: A skill that helps review code for best practices, bugs, and security issues
+---
+
+# Code Reviewer
+
+This skill helps you review code for common issues.
+
+## When to Use
+
+Use this skill when:
+- Reviewing pull requests
+- Checking code quality
+- Looking for security vulnerabilities
+
+## Guidelines
+
+1. Always check for:
+   - Null pointer exceptions
+   - SQL injection vulnerabilities
+   - Hardcoded secrets
+   - Missing error handling
+
+2. Provide constructive feedback with suggestions
+
+3. Prioritize issues by severity
+
+## Examples
+
+### Example 1: Security Review
+
+When asked "review this code for security issues", focus on:
+- Input validation
+- Authentication/authorization
+- Data sanitization
+
+### Example 2: Performance Review
+
+When asked about performance, check for:
+- N+1 queries
+- Unnecessary loops
+- Memory leaks

--- a/examples/skills/test-skill/tests.yaml
+++ b/examples/skills/test-skill/tests.yaml
@@ -1,0 +1,54 @@
+# Example skill test suite
+# Run with: evalview skill test examples/skills/test-skill/tests.yaml
+
+name: test-code-reviewer
+description: Tests for the code-reviewer skill
+
+# Path to the skill being tested (relative to this file or absolute)
+skill: ./SKILL.md
+
+# Model to use (optional, defaults to claude-sonnet-4-20250514)
+model: claude-sonnet-4-20250514
+
+# Minimum pass rate required (0-1)
+min_pass_rate: 0.8
+
+tests:
+  - name: detects-sql-injection
+    description: Should identify SQL injection vulnerability
+    input: |
+      Review this Python code for security issues:
+
+      def get_user(user_id):
+          query = f"SELECT * FROM users WHERE id = {user_id}"
+          return db.execute(query)
+    expected:
+      output_contains:
+        - "SQL injection"
+      output_not_contains:
+        - "looks good"
+        - "no issues"
+
+  - name: suggests-parameterized-queries
+    description: Should recommend parameterized queries as a fix
+    input: |
+      How do I fix this SQL injection vulnerability?
+
+      query = f"SELECT * FROM users WHERE id = {user_id}"
+    expected:
+      output_contains:
+        - "parameterized"
+
+  - name: identifies-hardcoded-secret
+    description: Should flag hardcoded API keys
+    input: |
+      Review this code:
+
+      API_KEY = "sk-1234567890abcdef"
+      response = requests.get(url, headers={"Authorization": API_KEY})
+    expected:
+      output_contains:
+        - "secret"
+      output_not_contains:
+        - "secure"
+        - "no issues"


### PR DESCRIPTION
## Summary

- Add `evalview skill validate` for structure validation
- Add `evalview skill test` for behavior testing  
- Add `evalview skill list` to discover skills in directories
- Support SKILL.md format (Claude Code, Codex CLI compatible)
- Policy compliance checking (prompt injection, role hijacking detection)
- Token size warnings (>5k tokens)
- Best practices suggestions (examples, guidelines sections)
- CI-friendly JSON output for all commands
- Example skill and test suite included

## New Commands

```bash
# Validate skill structure
evalview skill validate ./my-skill/SKILL.md
evalview skill validate ./skills/ -r

# Test skill behavior
evalview skill test tests/my-skill.yaml

# List skills
evalview skill list ~/.claude/skills/
```

## Test plan

- [x] Validated against official Anthropic skills repo (17 skills pass)
- [x] CLI help displays correctly
- [x] JSON output works for CI integration