### PR TITLE
feat: Add health_check() method to OllamaAdapter

### DIFF
--- a/evalview/adapters/ollama_adapter.py
+++ b/evalview/adapters/ollama_adapter.py
@@ -154,3 +154,12 @@ class OllamaAdapter(AgentAdapter):
             ),
             trace_context=trace_context,
         )
+
+    async def health_check(self) -> bool:
+        """Check if the Ollama server is reachable."""
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.get(f"{self.endpoint}/api/tags")
+                return response.status_code == 200
+        except httpx.RequestError:
+            return False

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 
 from evalview.adapters.http_adapter import HTTPAdapter
+from evalview.adapters.ollama_adapter import OllamaAdapter
 from evalview.core.types import ExecutionTrace
 
 
@@ -526,3 +527,60 @@ class TestHTTPAdapter:
             # Check that enable_tracing was sent
             call_args = mock_client.post.call_args
             assert call_args[1]["json"]["enable_tracing"] is True
+
+
+class TestOllamaAdapter:
+    """Tests for OllamaAdapter health checks."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_success(self):
+        """Test successful health check."""
+        adapter = OllamaAdapter(endpoint="http://localhost:11434")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = AsyncMock()
+            mock_response.status_code = 200
+            mock_client.get.return_value = mock_response
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            result = await adapter.health_check()
+
+            assert result is True
+            mock_client.get.assert_called_once_with("http://localhost:11434/api/tags")
+
+    @pytest.mark.asyncio
+    async def test_health_check_failure(self):
+        """Test failed health check."""
+        adapter = OllamaAdapter(endpoint="http://localhost:11434")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = AsyncMock()
+            mock_response.status_code = 500
+            mock_client.get.return_value = mock_response
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            result = await adapter.health_check()
+
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_health_check_wrong_port(self):
+        """Test health check with unreachable host/port."""
+        adapter = OllamaAdapter(endpoint="http://localhost:1")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = httpx.ConnectError("Connection refused")
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            result = await adapter.health_check()
+
+            assert result is False


### PR DESCRIPTION
## Description

Implemented the async health_check() method for OllamaAdapter to verify server availability.

## Related Issue

https://github.com/hidai25/eval-view/issues/36
Fixes #36

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added health_check() to OllamaAdapter using the /api/tags endpoint.
- Used httpx.RequestError to handle connection failures, following the existing HTTPAdapter pattern.
- Added 3 unit tests in tests/test_adapters.py covering: server success (200), server failure (500), and unreachable host (wrong port).

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

### Test Configuration

- **Python Version**: 3.13.7
- **OS**: Windows 11

### Tests Added/Modified

- [x] Unit tests added/updated
- [x] All tests pass locally
- [x] Test coverage maintained or improved

### Manual Testing Steps

1. Run py -m pytest tests/test_adapters.py -v to verify all 33 adapter tests pass.
2. Run py -m mypy evalview/adapters/ollama_adapter.py to ensure type safety.

## Checklist

### Code Quality

- [x] My code follows the project's style guidelines
- [x] I have run `mypy` and fixed any type errors
- [x] I have performed a self-review of my own code

### Documentation

- [x] I have added docstrings to new functions/classes

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Dependencies

- [x] I have checked that no new dependencies were added unnecessarily

## Screenshots

<img width="1270" height="946" alt="evalview2" src="https://github.com/user-attachments/assets/9adca16a-7693-4307-a042-efd31edf4684" />

## Additional Notes

The issue tips suggested using aiohttp. However, after reviewing the current implementation of HTTPAdapter.health_check() and pyproject.toml, I found the project is standardized on httpx. I used httpx to maintain consistency with the existing codebase.

## Reviewer Notes

Please verify that the transition to httpx for this adapter aligns with the project's long-term direction, as it differs from the suggestion in the issue description.

---

**By submitting this pull request, I confirm that:**

- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] I agree to the project's [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [x] My contribution is my own work and I have the right to contribute it
