### PR TITLE
feat: add basic Ollama local agent example with --no-judge mode

### DIFF
--- a/examples/ollama/.evalview/config.yaml
+++ b/examples/ollama/.evalview/config.yaml
@@ -1,6 +1,6 @@
 # EvalView Configuration for LangGraph + Ollama
 # Use local Llama model as the LLM-as-judge (free!)
-
+#examples\ollama\.evalview\config.yaml
 adapter: langgraph
 endpoint: http://localhost:2024
 timeout: 90

--- a/examples/ollama/README.md
+++ b/examples/ollama/README.md
@@ -1,3 +1,4 @@
+
 # Ollama Integration — Free, Offline AI Agent Testing with EvalView
 
 > Use Ollama with EvalView for completely free, fully offline AI agent testing and evaluation. No API keys needed, no cloud dependencies.

--- a/examples/ollama/basic-agent/.evalview/config.yaml
+++ b/examples/ollama/basic-agent/.evalview/config.yaml
@@ -1,0 +1,4 @@
+adapter: http
+endpoint: http://localhost:8123
+timeout: 120
+no_judge: true

--- a/examples/ollama/basic-agent/README.md
+++ b/examples/ollama/basic-agent/README.md
@@ -1,0 +1,64 @@
+# Basic Ollama Agent — Offline Testing with EvalView
+
+Test a fully local AI agent using Ollama and EvalView.
+**Zero cloud API keys required.**
+
+---
+
+## Requirements
+
+- [Ollama](https://ollama.com) installed and running
+- Python 3.8+
+- EvalView installed (`pip install evalview`)
+
+---
+
+## Setup
+
+**1. Pull the model:**
+```bash
+ollama pull llama3.2:1b
+```
+
+**2. Start the agent server:**
+```bash
+python agent.py serve
+```
+Leave this terminal open.
+
+**3. In a new terminal, run the eval:**
+```bash
+cd /path/to/eval-view
+python -m evalview run examples/ollama/basic-agent/basic-eval.yaml --no-judge
+```
+
+---
+
+## What this does
+
+- `agent.py` runs a local HTTP server on `localhost:8123` that forwards prompts to Ollama
+- `basic-eval.yaml` defines the test case and expected output
+- `--no-judge` skips LLM-as-judge scoring, uses deterministic scoring only (free, offline)
+
+---
+
+## Expected Output
+```
+✅ AGENT HEALTHY
+✓ Passed: 1    ✗ Failed: 0
+Score: 87.5/100   Cost: $0.0000
+```
+
+---
+
+## Save a baseline for regression detection
+```bash
+python -m evalview snapshot
+python -m evalview check   # run this on future changes
+```
+
+---
+
+## Model
+
+Uses `llama3.2:1b` by default. To change it, edit the `MODEL` variable in `agent.py`.

--- a/examples/ollama/basic-agent/agent.py
+++ b/examples/ollama/basic-agent/agent.py
@@ -1,0 +1,45 @@
+# examples/ollama/basic-agent/agent.py
+
+import requests
+import sys
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import json
+
+OLLAMA_URL = "http://localhost:11434/api/generate"
+MODEL = "llama3.2:1b"
+
+
+def run_agent(prompt: str) -> str:
+    try:
+        response = requests.post(
+            OLLAMA_URL,
+            json={"model": MODEL, "prompt": prompt, "stream": False},
+            timeout=120
+        )
+        response.raise_for_status()
+        return response.json().get("response", "")
+    except Exception as e:
+        return f"error: {e}"
+
+
+class AgentHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length))
+        prompt = body.get("query", body.get("input", ""))
+        output = run_agent(prompt)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"output": output}).encode())
+
+    def log_message(self, format, *args):
+        pass  # silence request logs
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] != "serve":
+        print(run_agent(" ".join(sys.argv[1:])))
+    else:
+        print("Starting agent server on http://localhost:8123")
+        HTTPServer(("localhost", 8123), AgentHandler).serve_forever()

--- a/examples/ollama/basic-agent/basic-eval.yaml
+++ b/examples/ollama/basic-agent/basic-eval.yaml
@@ -1,0 +1,20 @@
+name: "Basic Ollama Local Agent Test"
+description: "Test a simple local Ollama agent using --no-judge mode"
+
+adapter: http
+endpoint: http://localhost:8123
+
+input:
+  query: "Say hello"
+
+expected:
+  output:
+    contains:
+      - "hello"
+    not_contains:
+      - "error"
+      - "failed"
+
+thresholds:
+  min_score: 50
+  max_latency: 60000

--- a/examples/ollama/langgraph-ollama-test.yaml
+++ b/examples/ollama/langgraph-ollama-test.yaml
@@ -1,3 +1,4 @@
+#examples\ollama\langgraph-ollama-test.yaml
 # EvalView Test Case: LangGraph Agent with Ollama
 # Tests a local Llama-powered agent with tools
 


### PR DESCRIPTION
Closes #110

## What this adds
- `examples/ollama/basic-agent/agent.py`  local HTTP agent using Ollama
- `examples/ollama/basic-agent/basic-eval.yaml`  eval config with --no-judge
- `examples/ollama/basic-agent/.evalview/config.yaml` adapter config
- `examples/ollama/basic-agent/README.md` setup instructions

## Tested locally
✅ 1/1 tests passed
📊 Score: 87.5/100
💰 Cost: $0.00 
 zero API keys, fully local
🤖 Model: llama3.2:1b via Ollama

<img width="1920" height="1080" alt="Screenshot (221)" src="https://github.com/user-attachments/assets/e2674659-9a19-481b-94d8-51b99ffcb61e" />