### PR TITLE
Add Discord webhook support to monitor

### DIFF
--- a/evalview/cli.py
+++ b/evalview/cli.py
@@ -95,7 +95,7 @@ def main(ctx: click.Context) -> None:
     \b
     Production:
       watch                   Re-run checks on file change (local dev)
-      monitor                 Continuous regression detection (+ Slack alerts)
+      monitor                 Continuous regression detection (+ Slack/Discord alerts)
 
     \b
     CI/CD:

--- a/evalview/commands/monitor_cmd.py
+++ b/evalview/commands/monitor_cmd.py
@@ -1,4 +1,4 @@
-"""Monitor command — continuous regression detection with Slack alerts."""
+"""Monitor command - continuous regression detection with webhook alerts."""
 from __future__ import annotations
 
 import asyncio
@@ -14,11 +14,11 @@ from typing import Any, Dict, List, Optional, Set
 import click
 
 from evalview.commands.shared import (
-    console,
+    _analyze_check_diffs,
+    _execute_check_tests,
     _load_config_if_exists,
     _parse_fail_statuses,
-    _execute_check_tests,
-    _analyze_check_diffs,
+    console,
 )
 from evalview.core.diff import DiffStatus
 from evalview.telemetry.decorators import track_command
@@ -40,6 +40,20 @@ def _resolve_slack_webhook(
         if monitor_cfg.slack_webhook:
             return monitor_cfg.slack_webhook
     return os.environ.get("EVALVIEW_SLACK_WEBHOOK")
+
+
+def _resolve_discord_webhook(
+    cli_flag: Optional[str],
+    config: Any,
+) -> Optional[str]:
+    """Resolve Discord webhook URL with clear priority: CLI flag > config > env var."""
+    if cli_flag:
+        return cli_flag
+    if config:
+        monitor_cfg = config.get_monitor_config()
+        if monitor_cfg.discord_webhook:
+            return monitor_cfg.discord_webhook
+    return os.environ.get("EVALVIEW_DISCORD_WEBHOOK")
 
 
 def _append_history(history_path: Path, record: dict) -> None:
@@ -96,10 +110,27 @@ def _detect_spikes(
     return alerts
 
 
+def _build_notifiers(
+    slack_webhook: Optional[str],
+    discord_webhook: Optional[str],
+) -> List[tuple[str, Any]]:
+    """Build enabled webhook notifiers."""
+    from evalview.core.discord_notifier import DiscordNotifier
+    from evalview.core.slack_notifier import SlackNotifier
+
+    notifiers: List[tuple[str, Any]] = []
+    if slack_webhook:
+        notifiers.append(("Slack", SlackNotifier(slack_webhook)))
+    if discord_webhook:
+        notifiers.append(("Discord", DiscordNotifier(discord_webhook)))
+    return notifiers
+
+
 def _run_monitor_loop(
     test_path: str,
     interval: int,
     slack_webhook: Optional[str],
+    discord_webhook: Optional[str],
     fail_on: str,
     timeout: float,
     test_filter: Optional[str],
@@ -113,24 +144,21 @@ def _run_monitor_loop(
     Raises:
         MonitorError: If baselines or test cases are missing.
     """
-    from evalview.core.loader import TestCaseLoader
     from evalview.core.golden import GoldenStore
+    from evalview.core.loader import TestCaseLoader
     from evalview.core.messages import (
-        get_random_monitor_start_message,
-        get_random_monitor_cycle_message,
         get_random_monitor_clean_message,
+        get_random_monitor_cycle_message,
+        get_random_monitor_start_message,
     )
-    from evalview.core.slack_notifier import SlackNotifier
 
-    notifier = SlackNotifier(slack_webhook) if slack_webhook else None
+    notifiers = _build_notifiers(slack_webhook, discord_webhook)
 
-    # Verify snapshots exist
     store = GoldenStore()
     goldens = store.list_golden()
     if not goldens:
         raise MonitorError("No baselines found. Run `evalview snapshot` first.")
 
-    # Load test cases
     loader = TestCaseLoader()
     test_cases = loader.load_from_directory(Path(test_path))
 
@@ -141,10 +169,12 @@ def _run_monitor_loop(
 
     console.print(f"\n[cyan]{get_random_monitor_start_message()}[/cyan]")
     history_hint = f"  |  History: {history_path}" if history_path else ""
-    console.print(f"[dim]  Tests: {len(test_cases)}  |  Interval: {interval}s  |  Slack: {'✓' if notifier else '—'}{history_hint}[/dim]")
+    alert_targets = ", ".join(label for label, _ in notifiers) if notifiers else "None"
+    console.print(
+        f"[dim]  Tests: {len(test_cases)}  |  Interval: {interval}s  |  Alerts: {alert_targets}{history_hint}[/dim]"
+    )
     console.print("[dim]  Press Ctrl+C to stop.[/dim]\n")
 
-    # Track state across cycles
     previously_failing: Set[str] = set()
     cycle_count = 0
     total_cost = 0.0
@@ -157,7 +187,6 @@ def _run_monitor_loop(
         shutdown = True
 
     signal.signal(signal.SIGINT, _handle_sigint)
-
     fail_statuses = _parse_fail_statuses(fail_on)
 
     try:
@@ -171,23 +200,18 @@ def _run_monitor_loop(
                     test_cases, config, json_output=True, timeout=timeout
                 )
             except Exception as e:
-                console.print(f"[red]  ✗ Cycle {cycle_count} failed: {e}[/red]")
+                console.print(f"[red]  x Cycle {cycle_count} failed: {e}[/red]")
                 _sleep_interruptible(interval, lambda: shutdown)
                 continue
 
-            # Track cumulative cost
             cycle_cost = sum(r.trace.metrics.total_cost for r in results)
             total_cost += cycle_cost
-
             analysis = _analyze_check_diffs(diffs)
 
-            # Determine currently failing tests (only those matching fail_on)
-            currently_failing: Set[str] = set()
-            for name, diff in diffs:
-                if diff.overall_severity in fail_statuses:
-                    currently_failing.add(name)
+            currently_failing: Set[str] = {
+                name for name, diff in diffs if diff.overall_severity in fail_statuses
+            }
 
-            # Count severity buckets for history record and display
             regressions = sum(1 for _, d in diffs if d.overall_severity == DiffStatus.REGRESSION)
             tools_changed = sum(1 for _, d in diffs if d.overall_severity == DiffStatus.TOOLS_CHANGED)
             output_changed = sum(1 for _, d in diffs if d.overall_severity == DiffStatus.OUTPUT_CHANGED)
@@ -197,52 +221,50 @@ def _run_monitor_loop(
                 cost_part = f"  [dim]${cycle_cost:.4f}[/dim]" if cycle_cost > 0 else ""
                 console.print(f"[green]  {get_random_monitor_clean_message()} ({len(diffs)} tests){cost_part}[/green]")
 
-                # Send recovery if we were failing before
-                if previously_failing and notifier:
-                    asyncio.run(notifier.send_recovery_alert(len(diffs)))
-                    console.print("[dim]  📤 Slack: recovery notification sent[/dim]")
+                if previously_failing and notifiers:
+                    for label, notifier in notifiers:
+                        asyncio.run(notifier.send_recovery_alert(len(diffs)))
+                        console.print(f"[dim]  Alert: {label} recovery notification sent[/dim]")
             else:
-                # Show summary using analysis dict
                 parts = []
                 if analysis["has_regressions"]:
-                    parts.append(f"[red]{regressions} regression{'s' if regressions > 1 else ''}[/red]")
+                    parts.append(f"[red]{regressions} regression{'s' if regressions != 1 else ''}[/red]")
                 if analysis["has_tools_changed"]:
-                    parts.append(f"[yellow]{tools_changed} tool change{'s' if tools_changed > 1 else ''}[/yellow]")
+                    parts.append(f"[yellow]{tools_changed} tool change{'s' if tools_changed != 1 else ''}[/yellow]")
                 if analysis["has_output_changed"]:
-                    parts.append(f"[dim]{output_changed} output change{'s' if output_changed > 1 else ''}[/dim]")
+                    parts.append(f"[dim]{output_changed} output change{'s' if output_changed != 1 else ''}[/dim]")
 
-                console.print(f"  ⚠  {', '.join(parts)}")
+                console.print(f"  Warning: {', '.join(parts)}")
 
                 for name, diff in diffs:
                     if diff.overall_severity in fail_statuses:
-                        console.print(f"    [red]✗ {name}[/red] ({diff.overall_severity.value})")
+                        console.print(f"    [red]x {name}[/red] ({diff.overall_severity.value})")
 
-                # Only alert on NEW failures (avoid spamming)
                 new_failures = currently_failing - previously_failing
-                if new_failures and notifier:
+                if new_failures and notifiers:
                     alert_diffs = [(n, d) for n, d in diffs if n in currently_failing]
-                    asyncio.run(notifier.send_regression_alert(alert_diffs, analysis))
-                    console.print(f"[dim]  📤 Slack: alerted on {len(new_failures)} new failure(s)[/dim]")
+                    for label, notifier in notifiers:
+                        asyncio.run(notifier.send_regression_alert(alert_diffs, analysis))
+                        console.print(f"[dim]  Alert: {label} notified on {len(new_failures)} new failure(s)[/dim]")
 
-            # Detect cost/latency spikes against golden baselines
             spike_alerts = _detect_spikes(results, golden_traces, cost_threshold, latency_threshold)
             if spike_alerts:
                 for a in spike_alerts:
                     if a["alert_type"] == "cost_spike":
                         console.print(
-                            f"  [yellow]💰 {a['test_name']}: cost spike "
-                            f"${a['baseline']:.4f} → ${a['current']:.4f} ({a['multiplier']:.1f}x)[/yellow]"
+                            f"  [yellow]$ {a['test_name']}: cost spike "
+                            f"${a['baseline']:.4f} -> ${a['current']:.4f} ({a['multiplier']:.1f}x)[/yellow]"
                         )
                     else:
                         console.print(
-                            f"  [yellow]⏱  {a['test_name']}: latency spike "
-                            f"{a['baseline']:.1f}s → {a['current']:.1f}s ({a['multiplier']:.1f}x)[/yellow]"
+                            f"  [yellow]T {a['test_name']}: latency spike "
+                            f"{a['baseline']:.1f}s -> {a['current']:.1f}s ({a['multiplier']:.1f}x)[/yellow]"
                         )
-                if notifier:
-                    asyncio.run(notifier.send_cost_latency_alert(spike_alerts))
-                    console.print(f"[dim]  📤 Slack: {len(spike_alerts)} performance alert(s) sent[/dim]")
+                if notifiers:
+                    for label, notifier in notifiers:
+                        asyncio.run(notifier.send_cost_latency_alert(spike_alerts))
+                        console.print(f"[dim]  Alert: {label} sent {len(spike_alerts)} performance alert(s)[/dim]")
 
-            # Append cycle record to JSONL history file if requested
             if history_path is not None:
                 record = {
                     "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -260,12 +282,10 @@ def _run_monitor_loop(
                 _append_history(history_path, record)
 
             previously_failing = currently_failing
-
             _sleep_interruptible(interval, lambda: shutdown)
     finally:
         signal.signal(signal.SIGINT, original_sigint)
 
-    # Summary on exit
     console.print(f"\n[cyan]Monitor stopped after {cycle_count} cycle(s).[/cyan]")
     if total_cost > 0:
         console.print(f"[dim]  Total cost: ${total_cost:.4f}[/dim]")
@@ -278,6 +298,7 @@ def _run_monitor_dashboard(
     test_path: str,
     interval: int,
     slack_webhook: Optional[str],
+    discord_webhook: Optional[str],
     fail_on: str,
     timeout: float,
     test_filter: Optional[str],
@@ -286,21 +307,16 @@ def _run_monitor_dashboard(
     cost_threshold: Optional[float] = None,
     latency_threshold: Optional[float] = None,
 ) -> None:
-    """Monitor loop with a live-updating Rich dashboard.
-
-    Single screen that refreshes each cycle instead of scrolling logs.
-    """
+    """Monitor loop with a live-updating Rich dashboard."""
     from rich.live import Live
-    from rich.table import Table
     from rich.panel import Panel
+    from rich.table import Table
     from rich.text import Text
-    from rich.columns import Columns
 
-    from evalview.core.loader import TestCaseLoader
     from evalview.core.golden import GoldenStore
-    from evalview.core.slack_notifier import SlackNotifier
+    from evalview.core.loader import TestCaseLoader
 
-    notifier = SlackNotifier(slack_webhook) if slack_webhook else None
+    notifiers = _build_notifiers(slack_webhook, discord_webhook)
 
     store = GoldenStore()
     goldens = store.list_golden()
@@ -317,23 +333,21 @@ def _run_monitor_dashboard(
 
     fail_statuses = _parse_fail_statuses(fail_on)
 
-    # Status emoji for last-N history
-    _STATUS_EMOJI = {
-        DiffStatus.PASSED: "[green]●[/green]",
-        DiffStatus.TOOLS_CHANGED: "[yellow]●[/yellow]",
-        DiffStatus.OUTPUT_CHANGED: "[yellow]●[/yellow]",
-        DiffStatus.REGRESSION: "[red]●[/red]",
+    status_dot = {
+        DiffStatus.PASSED: "[green]o[/green]",
+        DiffStatus.TOOLS_CHANGED: "[yellow]o[/yellow]",
+        DiffStatus.OUTPUT_CHANGED: "[yellow]o[/yellow]",
+        DiffStatus.REGRESSION: "[red]o[/red]",
     }
 
-    # Track state
     previously_failing: Set[str] = set()
     cycle_count = 0
     total_cost = 0.0
     start_time = time.time()
     last_check_time = ""
     next_check_time = ""
-    slack_alerts_sent = 0
-    test_history: Dict[str, List[DiffStatus]] = {}  # test_name → last N statuses
+    alerts_sent = 0
+    test_history: Dict[str, List[DiffStatus]] = {}
     current_statuses: Dict[str, DiffStatus] = {}
     checking = False
     error_msg = ""
@@ -348,19 +362,16 @@ def _run_monitor_dashboard(
     signal.signal(signal.SIGINT, _handle_sigint)
 
     def _build_dashboard() -> Panel:
-        """Build the dashboard panel for the current state."""
         uptime_secs = int(time.time() - start_time)
         uptime_m = uptime_secs // 60
         uptime_s = uptime_secs % 60
 
-        # Header stats
         header = Text()
         header.append(f"  Cycle: {cycle_count}", style="bold")
         header.append(f"  |  Uptime: {uptime_m}m{uptime_s:02d}s")
         header.append(f"  |  Cost: ${total_cost:.4f}")
-        header.append(f"  |  Slack: {slack_alerts_sent} alert{'s' if slack_alerts_sent != 1 else ''}")
+        header.append(f"  |  Alerts: {alerts_sent} sent")
 
-        # Test table
         table = Table(show_header=True, header_style="bold", expand=True, padding=(0, 1))
         table.add_column("Test", style="bold", ratio=3)
         table.add_column("Status", ratio=2)
@@ -383,17 +394,13 @@ def _run_monitor_dashboard(
             else:
                 status_str = f"[dim]{status.value}[/dim]"
 
-            # History dots (last 5 cycles)
             history = test_history.get(name, [])
-            dots = " ".join(
-                _STATUS_EMOJI.get(s, "[dim]○[/dim]") for s in history[-5:]
-            )
+            dots = " ".join(status_dot.get(s, "[dim].[/dim]") for s in history[-5:])
             if not dots:
-                dots = "[dim]○ ○ ○ ○ ○[/dim]"
+                dots = "[dim]. . . . .[/dim]"
 
             table.add_row(name, status_str, dots)
 
-        # Footer
         footer = Text()
         if checking:
             footer.append("  Checking...", style="cyan")
@@ -404,14 +411,13 @@ def _run_monitor_dashboard(
             footer.append(f"  |  Next: {next_check_time}", style="dim")
         footer.append("  |  Press Ctrl+C to stop", style="dim")
 
-        # Assemble
         from rich.console import Group
+
         content = Group(header, "", table, "", footer)
         return Panel(content, title="EvalView Monitor", border_style="blue")
 
     with Live(_build_dashboard(), console=console, refresh_per_second=1) as live:
         while not shutdown:
-            # Run check cycle
             cycle_count += 1
             checking = True
             last_check_time = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
@@ -430,8 +436,6 @@ def _run_monitor_dashboard(
                 continue
 
             checking = False
-
-            # Update state
             cycle_cost = sum(r.trace.metrics.total_cost for r in results)
             total_cost += cycle_cost
 
@@ -441,30 +445,29 @@ def _run_monitor_dashboard(
                     test_history[name] = []
                 test_history[name].append(diff.overall_severity)
 
-            # Slack alerts (same logic as scrolling mode)
-            currently_failing: Set[str] = set()
-            for name, diff in diffs:
-                if diff.overall_severity in fail_statuses:
-                    currently_failing.add(name)
+            currently_failing: Set[str] = {
+                name for name, diff in diffs if diff.overall_severity in fail_statuses
+            }
 
-            if not currently_failing and previously_failing and notifier:
-                asyncio.run(notifier.send_recovery_alert(len(diffs)))
-                slack_alerts_sent += 1
+            if not currently_failing and previously_failing and notifiers:
+                for notifier in notifiers:
+                    asyncio.run(notifier[1].send_recovery_alert(len(diffs)))
+                    alerts_sent += 1
 
             new_failures = currently_failing - previously_failing
-            if new_failures and notifier:
+            if new_failures and notifiers:
                 alert_diffs = [(n, d) for n, d in diffs if n in currently_failing]
                 analysis = _analyze_check_diffs(diffs)
-                asyncio.run(notifier.send_regression_alert(alert_diffs, analysis))
-                slack_alerts_sent += 1
+                for notifier in notifiers:
+                    asyncio.run(notifier[1].send_regression_alert(alert_diffs, analysis))
+                    alerts_sent += 1
 
-            # Cost/latency spike alerts
             spike_alerts = _detect_spikes(results, golden_traces, cost_threshold, latency_threshold)
-            if spike_alerts and notifier:
-                asyncio.run(notifier.send_cost_latency_alert(spike_alerts))
-                slack_alerts_sent += 1
+            if spike_alerts and notifiers:
+                for notifier in notifiers:
+                    asyncio.run(notifier[1].send_cost_latency_alert(spike_alerts))
+                    alerts_sent += 1
 
-            # History file
             if history_path is not None:
                 regressions = sum(1 for _, d in diffs if d.overall_severity == DiffStatus.REGRESSION)
                 tools_changed = sum(1 for _, d in diffs if d.overall_severity == DiffStatus.TOOLS_CHANGED)
@@ -484,12 +487,9 @@ def _run_monitor_dashboard(
                 _append_history(history_path, record)
 
             previously_failing = currently_failing
-
-            # Update dashboard and wait
             next_time = datetime.now(timezone.utc).timestamp() + interval
             next_check_time = datetime.fromtimestamp(next_time, tz=timezone.utc).strftime("%H:%M:%S UTC")
             live.update(_build_dashboard())
-
             _sleep_interruptible(interval, lambda: shutdown)
 
     signal.signal(signal.SIGINT, original_sigint)
@@ -511,6 +511,7 @@ def _sleep_interruptible(seconds: int, should_stop: Any) -> None:
 @click.argument("test_path", default="tests", type=click.Path(exists=True))
 @click.option("--interval", "-i", type=int, default=None, help="Seconds between checks (default: 300)")
 @click.option("--slack-webhook", default=None, help="Slack webhook URL for alerts")
+@click.option("--discord-webhook", default=None, help="Discord webhook URL for alerts")
 @click.option("--fail-on", default=None, help="Comma-separated statuses that trigger alerts (default: REGRESSION)")
 @click.option("--timeout", type=float, default=None, help="Timeout per test in seconds (default: 30)")
 @click.option("--test", "-t", "test_filter", default=None, help="Monitor only this specific test")
@@ -529,6 +530,7 @@ def monitor(
     test_path: str,
     interval: Optional[int],
     slack_webhook: Optional[str],
+    discord_webhook: Optional[str],
     fail_on: Optional[str],
     timeout: Optional[float],
     test_filter: Optional[str],
@@ -537,36 +539,38 @@ def monitor(
     latency_spike: Optional[float],
     dashboard: bool = False,
 ) -> None:
-    """Continuously check for regressions with optional Slack alerts.
+    """Continuously check for regressions with optional webhook alerts.
 
     Runs evalview check in a loop, alerting you when regressions appear
-    and notifying when they're resolved. Designed for production monitoring.
+    and notifying when they are resolved. Designed for production monitoring.
 
     \b
     Examples:
         evalview monitor                                # Check every 5 min
         evalview monitor --interval 60                  # Check every minute
         evalview monitor --slack-webhook https://...    # Alert to Slack
+        evalview monitor --discord-webhook https://...  # Alert to Discord
         evalview monitor --test "weather-lookup"        # Monitor one test
         evalview monitor --fail-on REGRESSION,TOOLS_CHANGED
         evalview monitor --history monitor_log.jsonl    # Persist cycle history
-        evalview monitor --alert-cost-spike 2.0        # Alert if cost doubles
-        evalview monitor --alert-latency-spike 3.0     # Alert if latency triples
+        evalview monitor --alert-cost-spike 2.0         # Alert if cost doubles
+        evalview monitor --alert-latency-spike 3.0      # Alert if latency triples
 
     \b
     Configuration (config.yaml):
         monitor:
           interval: 300
           slack_webhook: https://hooks.slack.com/services/...
+          discord_webhook: https://discord.com/api/webhooks/...
           fail_on: [REGRESSION]
           cost_threshold: 2.0
           latency_threshold: 3.0
 
     \b
     Environment variables:
-        EVALVIEW_SLACK_WEBHOOK    Slack webhook URL (fallback)
+        EVALVIEW_SLACK_WEBHOOK     Slack webhook URL (fallback)
+        EVALVIEW_DISCORD_WEBHOOK   Discord webhook URL (fallback)
     """
-    # Resolve defaults from config file
     from evalview.core.config import apply_judge_config
 
     config = _load_config_if_exists()
@@ -588,13 +592,16 @@ def monitor(
     resolved_history = Path(history_path) if history_path else None
     resolved_cost_threshold = cost_spike or (monitor_cfg.cost_threshold if monitor_cfg else None)
     resolved_latency_threshold = latency_spike or (monitor_cfg.latency_threshold if monitor_cfg else None)
+    resolved_slack_webhook = _resolve_slack_webhook(slack_webhook, config)
+    resolved_discord_webhook = _resolve_discord_webhook(discord_webhook, config)
 
     try:
         if dashboard:
             _run_monitor_dashboard(
                 test_path=test_path,
                 interval=resolved_interval,
-                slack_webhook=_resolve_slack_webhook(slack_webhook, config),
+                slack_webhook=resolved_slack_webhook,
+                discord_webhook=resolved_discord_webhook,
                 fail_on=resolved_fail_on,
                 timeout=resolved_timeout,
                 test_filter=test_filter,
@@ -607,7 +614,8 @@ def monitor(
             _run_monitor_loop(
                 test_path=test_path,
                 interval=resolved_interval,
-                slack_webhook=_resolve_slack_webhook(slack_webhook, config),
+                slack_webhook=resolved_slack_webhook,
+                discord_webhook=resolved_discord_webhook,
                 fail_on=resolved_fail_on,
                 timeout=resolved_timeout,
                 test_filter=test_filter,
@@ -617,5 +625,5 @@ def monitor(
                 latency_threshold=resolved_latency_threshold,
             )
     except MonitorError as e:
-        console.print(f"[red]❌ {e}[/red]")
+        console.print(f"[red]ERROR {e}[/red]")
         sys.exit(1)

--- a/evalview/core/config.py
+++ b/evalview/core/config.py
@@ -163,6 +163,7 @@ class MonitorConfig(BaseModel):
         monitor:
           interval: 300
           slack_webhook: https://hooks.slack.com/services/...
+          discord_webhook: https://discord.com/api/webhooks/...
           fail_on: [REGRESSION]
           timeout: 60
     """
@@ -175,6 +176,10 @@ class MonitorConfig(BaseModel):
     slack_webhook: Optional[str] = Field(
         default=None,
         description="Slack incoming webhook URL for regression alerts"
+    )
+    discord_webhook: Optional[str] = Field(
+        default=None,
+        description="Discord webhook URL for regression alerts"
     )
     fail_on: list = Field(
         default=["REGRESSION"],

--- a/evalview/core/discord_notifier.py
+++ b/evalview/core/discord_notifier.py
@@ -1,0 +1,109 @@
+"""Discord webhook notifier for EvalView monitor alerts."""
+
+from typing import Any, Dict, List, Tuple
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class DiscordNotifier:
+    """Send regression alerts to Discord via incoming webhook."""
+
+    def __init__(self, webhook_url: str):
+        self.webhook_url = webhook_url
+
+    async def send_regression_alert(
+        self,
+        diffs: List[Tuple[str, Any]],
+        analysis: Dict[str, Any],
+    ) -> bool:
+        """Send a regression alert to Discord."""
+        from evalview.core.diff import DiffStatus
+        from evalview.core.root_cause import analyze_root_cause
+
+        failing = []
+        for name, diff in diffs:
+            root_cause = analyze_root_cause(diff)
+            cause_line = f"\n  _{root_cause.summary}_" if root_cause is not None else ""
+
+            if diff.overall_severity == DiffStatus.REGRESSION:
+                score_part = f" (score {diff.score_diff:+.1f})" if diff.score_diff is not None else ""
+                failing.append(f":red_circle: **{name}** - REGRESSION{score_part}{cause_line}")
+            elif diff.overall_severity == DiffStatus.TOOLS_CHANGED:
+                failing.append(f":orange_circle: **{name}** - TOOLS_CHANGED{cause_line}")
+            elif diff.overall_severity == DiffStatus.OUTPUT_CHANGED:
+                failing.append(f":white_circle: **{name}** - OUTPUT_CHANGED{cause_line}")
+
+        if not failing:
+            return True
+
+        total = len(diffs)
+        passed = sum(1 for _, d in diffs if d.overall_severity == DiffStatus.PASSED)
+
+        text = (
+            ":warning: **EvalView Monitor - Regression Detected**\n\n"
+            f"{passed}/{total} tests passing\n\n"
+            + "\n".join(failing)
+            + "\n\nRun `evalview check` for full details."
+        )
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.post(self.webhook_url, json={"content": text})
+                resp.raise_for_status()
+                return True
+        except Exception as e:
+            logger.warning("Discord notification failed: %s", e)
+            return False
+
+    async def send_cost_latency_alert(
+        self,
+        alerts: List[Dict[str, Any]],
+    ) -> bool:
+        """Send cost/latency spike alerts to Discord."""
+        lines = []
+        for a in alerts:
+            if a["alert_type"] == "cost_spike":
+                lines.append(
+                    f":money_with_wings: **{a['test_name']}** - cost spike: "
+                    f"${a['baseline']:.4f} -> ${a['current']:.4f} ({a['multiplier']:.1f}x)"
+                )
+            else:
+                lines.append(
+                    f":hourglass: **{a['test_name']}** - latency spike: "
+                    f"{a['baseline']:.1f}s -> {a['current']:.1f}s ({a['multiplier']:.1f}x)"
+                )
+
+        text = (
+            ":chart_with_upwards_trend: **EvalView Monitor - Performance Alert**\n\n"
+            + "\n".join(lines)
+            + "\n\nRun `evalview check` for full details."
+        )
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.post(self.webhook_url, json={"content": text})
+                resp.raise_for_status()
+                return True
+        except Exception as e:
+            logger.warning("Discord notification failed: %s", e)
+            return False
+
+    async def send_recovery_alert(self, total_tests: int) -> bool:
+        """Send a recovery notification when all tests pass again."""
+        payload = {
+            "content": (
+                ":white_check_mark: **EvalView Monitor - All Clear**\n\n"
+                f"All {total_tests} tests passing. Regression resolved."
+            )
+        }
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.post(self.webhook_url, json=payload)
+                resp.raise_for_status()
+                return True
+        except Exception as e:
+            logger.warning("Discord notification failed: %s", e)
+            return False

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -141,6 +141,7 @@ class TestMonitorConfig:
         c = MonitorConfig()
         assert c.interval == 300
         assert c.slack_webhook is None
+        assert c.discord_webhook is None
         assert c.fail_on == ["REGRESSION"]
         assert c.timeout == 30.0
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,4 +1,4 @@
-"""Tests for the monitor command and Slack notifier."""
+"""Tests for the monitor command and webhook notifiers."""
 
 import asyncio
 import json
@@ -13,10 +13,12 @@ import yaml
 from evalview.commands.monitor_cmd import (
     MonitorError,
     _append_history,
+    _resolve_discord_webhook,
     _resolve_slack_webhook,
     _run_monitor_loop,
     _sleep_interruptible,
 )
+from evalview.core.discord_notifier import DiscordNotifier
 from evalview.core.diff import DiffStatus
 from evalview.core.slack_notifier import SlackNotifier
 
@@ -139,6 +141,40 @@ class TestResolveSlackWebhook:
         assert result == "https://env-url"
 
 
+class TestResolveDiscordWebhook:
+    """Test webhook URL priority: CLI flag > config > env var."""
+
+    def test_cli_flag_wins(self):
+        config = MagicMock()
+        config.get_monitor_config.return_value.discord_webhook = "https://config-url"
+        result = _resolve_discord_webhook("https://cli-url", config)
+        assert result == "https://cli-url"
+
+    def test_config_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv("EVALVIEW_DISCORD_WEBHOOK", "https://env-url")
+        config = MagicMock()
+        config.get_monitor_config.return_value.discord_webhook = "https://config-url"
+        result = _resolve_discord_webhook(None, config)
+        assert result == "https://config-url"
+
+    def test_env_var_fallback(self, monkeypatch):
+        monkeypatch.setenv("EVALVIEW_DISCORD_WEBHOOK", "https://env-url")
+        result = _resolve_discord_webhook(None, None)
+        assert result == "https://env-url"
+
+    def test_returns_none_when_nothing_set(self, monkeypatch):
+        monkeypatch.delenv("EVALVIEW_DISCORD_WEBHOOK", raising=False)
+        result = _resolve_discord_webhook(None, None)
+        assert result is None
+
+    def test_config_with_no_webhook_falls_through(self, monkeypatch):
+        monkeypatch.setenv("EVALVIEW_DISCORD_WEBHOOK", "https://env-url")
+        config = MagicMock()
+        config.get_monitor_config.return_value.discord_webhook = None
+        result = _resolve_discord_webhook(None, config)
+        assert result == "https://env-url"
+
+
 # ---------------------------------------------------------------------------
 # MonitorError on missing prerequisites
 # ---------------------------------------------------------------------------
@@ -157,6 +193,7 @@ class TestMonitorPrerequisites:
                 test_path="tests",
                 interval=10,
                 slack_webhook=None,
+                discord_webhook=None,
                 fail_on="REGRESSION",
                 timeout=30.0,
                 test_filter=None,
@@ -173,6 +210,7 @@ class TestMonitorPrerequisites:
                 test_path="tests",
                 interval=10,
                 slack_webhook=None,
+                discord_webhook=None,
                 fail_on="REGRESSION",
                 timeout=30.0,
                 test_filter="nonexistent-test",
@@ -302,6 +340,96 @@ class TestSlackNotifier:
         assert result is False
 
 
+class TestDiscordNotifier:
+    """Test Discord notification formatting and delivery."""
+
+    def test_regression_alert_includes_test_names(self):
+        notifier = DiscordNotifier("https://discord.com/api/webhooks/test")
+
+        diff_reg = _make_diff("REGRESSION", score_diff=-15.0)
+        diff_tool = _make_diff("TOOLS_CHANGED")
+        diffs = [("auth-flow", diff_reg), ("search-api", diff_tool)]
+        analysis = {"has_regressions": True, "has_tools_changed": True}
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status = MagicMock()
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = asyncio.run(notifier.send_regression_alert(diffs, analysis))
+
+        assert result is True
+        call_args = mock_client.post.call_args
+        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        assert "auth-flow" in payload["content"]
+        assert "search-api" in payload["content"]
+        assert "REGRESSION" in payload["content"]
+
+    def test_regression_alert_handles_none_score_diff(self):
+        notifier = DiscordNotifier("https://discord.com/api/webhooks/test")
+
+        diff = _make_diff("REGRESSION")
+        diff.score_diff = None
+        diffs = [("my-test", diff)]
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status = MagicMock()
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = asyncio.run(notifier.send_regression_alert(diffs, {}))
+
+        assert result is True
+
+    def test_recovery_alert_message(self):
+        notifier = DiscordNotifier("https://discord.com/api/webhooks/test")
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status = MagicMock()
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = asyncio.run(notifier.send_recovery_alert(5))
+
+        assert result is True
+        call_args = mock_client.post.call_args
+        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        assert "All Clear" in payload["content"]
+        assert "5" in payload["content"]
+
+    def test_empty_diffs_returns_true(self):
+        notifier = DiscordNotifier("https://discord.com/api/webhooks/test")
+        diff = _make_diff("PASSED")
+        result = asyncio.run(notifier.send_regression_alert([("ok", diff)], {}))
+        assert result is True
+
+    def test_network_failure_returns_false(self):
+        notifier = DiscordNotifier("https://discord.com/api/webhooks/test")
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=Exception("Network down"))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = asyncio.run(notifier.send_recovery_alert(3))
+
+        assert result is False
+
+
 # ---------------------------------------------------------------------------
 # MonitorConfig
 # ---------------------------------------------------------------------------
@@ -314,6 +442,7 @@ class TestMonitorConfig:
         cfg = MonitorConfig()
         assert cfg.interval == 300
         assert cfg.slack_webhook is None
+        assert cfg.discord_webhook is None
         assert cfg.fail_on == ["REGRESSION"]
         assert cfg.timeout == 30.0
 


### PR DESCRIPTION
## Description

Adds Discord webhook support to `evalview monitor`, matching the existing Slack alert flow for regressions, recoveries, and performance spikes.

## Related Issue

Fixes #80

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test improvements
- [ ] CI/CD improvements

## Changes Made

- Added `DiscordNotifier` in `evalview/core/discord_notifier.py` with `send_regression_alert()`, `send_recovery_alert()`, and performance alert support.
- Added `--discord-webhook` support to `evalview monitor` with the same priority chain as Slack: CLI flag > config > env var.
- Added config support for `monitor.discord_webhook` and environment variable fallback via `EVALVIEW_DISCORD_WEBHOOK`.
- Updated monitor flow to support Slack and Discord webhook notifications in parallel.
- Added tests for Discord webhook resolution, Discord notifier payloads, and monitor config defaults.

## Testing

Ran the focused monitor/config test suite after setting writable local temp directories for pytest on Windows.

### Test Configuration

- **Python Version**: 3.12.4
- **OS**: Windows

### Tests Added/Modified

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally
- [x] Test coverage maintained or improved

### Manual Testing Steps

1. Configure a Discord webhook using `--discord-webhook`, `monitor.discord_webhook`, or `EVALVIEW_DISCORD_WEBHOOK`.
2. Run `evalview monitor` against a test suite with baselines.
3. Verify regression and recovery alerts are delivered to Discord in the same scenarios as Slack.

## Checklist

### Code Quality

- [x] My code follows the project's style guidelines
- [ ] I have run `black` to format my code
- [ ] I have run `ruff` and fixed any linting issues
- [ ] I have run `mypy` and fixed any type errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Documentation

- [ ] I have updated the documentation (README, CONTRIBUTING, etc.)
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md (if applicable)

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this with multiple agent frameworks (if applicable)

### Dependencies

- [x] I have checked that no new dependencies were added unnecessarily
- [ ] If dependencies were added, I have updated `pyproject.toml`
- [x] I have verified that the new dependencies are compatible with Python 3.9+

## Breaking Changes

None.

## Screenshots (if applicable)

N/A

## Additional Notes

This change reuses the existing monitor alert structure so Discord support behaves consistently with Slack while using Discord's webhook payload format (`content`).

## Reviewer Notes

Please pay special attention to:
- webhook priority resolution for CLI/config/env
- parity between Slack and Discord notifier behavior
- monitor command support for sending alerts to both channels

---

**By submitting this pull request, I confirm that:**

- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] I agree to the project's [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [x] My contribution is my own work and I have the right to contribute it
