### PR TITLE
feat(noise): confirmation gate, incident collapse, public noise metric + strict bypass

### DIFF
--- a/evalview/commands/monitor_cmd.py
+++ b/evalview/commands/monitor_cmd.py
@@ -172,11 +172,25 @@ def _run_monitor_loop(
         if not test_cases:
             raise MonitorError(f"No test found with name: {test_filter}")
 
+    # Tests tagged `gate: strict` in their YAML bypass the confirmation
+    # gate — they alert on n=1. Use this for safety-critical behaviors
+    # (auth, payments, PII, refunds) where a one-cycle blip is worth
+    # investigating immediately rather than waiting for confirmation.
+    strict_tests: Set[str] = {
+        tc.name
+        for tc in test_cases
+        if (getattr(tc, "gate", None) or "").lower() == "strict"
+    }
+
     console.print(f"\n[cyan]{get_random_monitor_start_message()}[/cyan]")
     history_hint = f"  |  History: {history_path}" if history_path else ""
     alert_targets = ", ".join(label for label, _ in notifiers) if notifiers else "None"
+    strict_hint = (
+        f"  |  Strict: {len(strict_tests)}" if strict_tests else ""
+    )
     console.print(
-        f"[dim]  Tests: {len(test_cases)}  |  Interval: {interval}s  |  Alerts: {alert_targets}{history_hint}[/dim]"
+        f"[dim]  Tests: {len(test_cases)}  |  Interval: {interval}s  |  "
+        f"Alerts: {alert_targets}{strict_hint}{history_hint}[/dim]"
     )
     console.print("[dim]  Press Ctrl+C to stop.[/dim]\n")
 
@@ -185,7 +199,8 @@ def _run_monitor_loop(
     # to persist into a second cycle before paging a human. This is the
     # single highest-leverage noise-reduction lever: it reframes the
     # product's emotional contract so every alert a user sees is one
-    # that survived at least two independent runs.
+    # that survived at least two independent runs. Strict tests bypass
+    # the gate so safety-critical behaviors still page on n=1.
     gate = ConfirmationGate()
     cycle_count = 0
     total_cost = 0.0
@@ -230,9 +245,17 @@ def _run_monitor_loop(
 
             # Run the cycle's failures through the confirmation gate. Only
             # the `decision.alerts_to_fire` set should reach a notifier.
-            decision = gate.evaluate(currently_failing)
+            # Strict-tagged tests bypass the gate (alert on n=1).
+            decision = gate.evaluate(currently_failing, strict=strict_tests)
             record_cycle_noise(decision)
 
+            if decision.strict_immediate:
+                names = ", ".join(sorted(decision.strict_immediate))
+                console.print(
+                    f"[yellow]  Gate: {len(decision.strict_immediate)} "
+                    f"strict failure(s) ({names}) — bypassing confirmation, "
+                    f"alerting now[/yellow]"
+                )
             if decision.self_resolved:
                 names = ", ".join(sorted(decision.self_resolved))
                 console.print(
@@ -240,9 +263,10 @@ def _run_monitor_loop(
                     f"unconfirmed failure(s) ({names}) — recovered before alerting[/dim]"
                 )
             if decision.pending:
+                names = ", ".join(sorted(decision.pending))
                 console.print(
                     f"[dim]  Gate: {len(decision.pending)} failure(s) pending "
-                    f"confirmation — will alert if still failing next cycle[/dim]"
+                    f"confirmation ({names}) — will alert if still failing next cycle[/dim]"
                 )
 
             if not currently_failing:
@@ -380,6 +404,14 @@ def _run_monitor_dashboard(
         if not test_cases:
             raise MonitorError(f"No test found with name: {test_filter}")
 
+    # Strict-tagged tests bypass the confirmation gate — see CLI loop
+    # for the rationale.
+    strict_tests: Set[str] = {
+        tc.name
+        for tc in test_cases
+        if (getattr(tc, "gate", None) or "").lower() == "strict"
+    }
+
     fail_statuses = _parse_fail_statuses(fail_on)
 
     status_dot = {
@@ -391,7 +423,8 @@ def _run_monitor_dashboard(
 
     previously_failing: Set[str] = set()
     # See `_run_monitor_loop` for the confirmation-gate rationale — same
-    # pattern applies to the dashboard variant.
+    # pattern applies to the dashboard variant. Strict tests bypass the
+    # gate and alert on n=1.
     gate = ConfirmationGate()
     cycle_count = 0
     total_cost = 0.0
@@ -503,7 +536,7 @@ def _run_monitor_dashboard(
             }
 
             # Confirmation gate: suppress n=1 alerts and record noise stats.
-            decision = gate.evaluate(currently_failing)
+            decision = gate.evaluate(currently_failing, strict=strict_tests)
             record_cycle_noise(decision)
             alerts_suppressed += len(decision.self_resolved)
 

--- a/evalview/commands/monitor_cmd.py
+++ b/evalview/commands/monitor_cmd.py
@@ -21,6 +21,11 @@ from evalview.commands.shared import (
     console,
 )
 from evalview.core.diff import DiffStatus
+from evalview.core.noise_tracker import (
+    ConfirmationGate,
+    detect_coordinated_incident,
+    record_cycle_noise,
+)
 from evalview.telemetry.decorators import track_command
 
 
@@ -176,6 +181,12 @@ def _run_monitor_loop(
     console.print("[dim]  Press Ctrl+C to stop.[/dim]\n")
 
     previously_failing: Set[str] = set()
+    # Confirmation gate — suppresses n=1 alerts by requiring a failure
+    # to persist into a second cycle before paging a human. This is the
+    # single highest-leverage noise-reduction lever: it reframes the
+    # product's emotional contract so every alert a user sees is one
+    # that survived at least two independent runs.
+    gate = ConfirmationGate()
     cycle_count = 0
     total_cost = 0.0
     shutdown = False
@@ -217,6 +228,23 @@ def _run_monitor_loop(
             output_changed = sum(1 for _, d in diffs if d.overall_severity == DiffStatus.OUTPUT_CHANGED)
             passed = len(diffs) - regressions - tools_changed - output_changed
 
+            # Run the cycle's failures through the confirmation gate. Only
+            # the `decision.alerts_to_fire` set should reach a notifier.
+            decision = gate.evaluate(currently_failing)
+            record_cycle_noise(decision)
+
+            if decision.self_resolved:
+                names = ", ".join(sorted(decision.self_resolved))
+                console.print(
+                    f"[dim]  Gate: suppressed {len(decision.self_resolved)} "
+                    f"unconfirmed failure(s) ({names}) — recovered before alerting[/dim]"
+                )
+            if decision.pending:
+                console.print(
+                    f"[dim]  Gate: {len(decision.pending)} failure(s) pending "
+                    f"confirmation — will alert if still failing next cycle[/dim]"
+                )
+
             if not currently_failing:
                 cost_part = f"  [dim]${cycle_cost:.4f}[/dim]" if cycle_cost > 0 else ""
                 console.print(f"[green]  {get_random_monitor_clean_message()} ({len(diffs)} tests){cost_part}[/green]")
@@ -240,12 +268,33 @@ def _run_monitor_loop(
                     if diff.overall_severity in fail_statuses:
                         console.print(f"    [red]x {name}[/red] ({diff.overall_severity.value})")
 
-                new_failures = currently_failing - previously_failing
-                if new_failures and notifiers:
-                    alert_diffs = [(n, d) for n, d in diffs if n in currently_failing]
+                # Fire alerts only for failures confirmed by the gate —
+                # everything that just started failing this cycle waits
+                # one cycle before it can page anyone.
+                alerts_to_fire = decision.alerts_to_fire
+                if alerts_to_fire and notifiers:
+                    alert_diffs = [(n, d) for n, d in diffs if n in alerts_to_fire]
+                    # Collapse correlated failures into a single incident card
+                    # when they share a common root cause — the notifier
+                    # will use `incident.headline` as the summary instead
+                    # of listing each test separately.
+                    incident = detect_coordinated_incident(alert_diffs)
                     for label, notifier in notifiers:
-                        asyncio.run(notifier.send_regression_alert(alert_diffs, analysis))
-                        console.print(f"[dim]  Alert: {label} notified on {len(new_failures)} new failure(s)[/dim]")
+                        asyncio.run(
+                            notifier.send_regression_alert(
+                                alert_diffs, analysis, incident=incident
+                            )
+                        )
+                        if incident is not None:
+                            console.print(
+                                f"[dim]  Alert: {label} sent 1 incident "
+                                f"({incident.cause}, {len(alert_diffs)} tests)[/dim]"
+                            )
+                        else:
+                            console.print(
+                                f"[dim]  Alert: {label} notified on "
+                                f"{len(alerts_to_fire)} confirmed failure(s)[/dim]"
+                            )
 
             spike_alerts = _detect_spikes(results, golden_traces, cost_threshold, latency_threshold)
             if spike_alerts:
@@ -341,12 +390,16 @@ def _run_monitor_dashboard(
     }
 
     previously_failing: Set[str] = set()
+    # See `_run_monitor_loop` for the confirmation-gate rationale — same
+    # pattern applies to the dashboard variant.
+    gate = ConfirmationGate()
     cycle_count = 0
     total_cost = 0.0
     start_time = time.time()
     last_check_time = ""
     next_check_time = ""
     alerts_sent = 0
+    alerts_suppressed = 0
     test_history: Dict[str, List[DiffStatus]] = {}
     current_statuses: Dict[str, DiffStatus] = {}
     checking = False
@@ -449,17 +502,27 @@ def _run_monitor_dashboard(
                 name for name, diff in diffs if diff.overall_severity in fail_statuses
             }
 
+            # Confirmation gate: suppress n=1 alerts and record noise stats.
+            decision = gate.evaluate(currently_failing)
+            record_cycle_noise(decision)
+            alerts_suppressed += len(decision.self_resolved)
+
             if not currently_failing and previously_failing and notifiers:
                 for label, notifier in notifiers:
                     asyncio.run(notifier.send_recovery_alert(len(diffs)))
                     alerts_sent += 1
 
-            new_failures = currently_failing - previously_failing
-            if new_failures and notifiers:
-                alert_diffs = [(n, d) for n, d in diffs if n in currently_failing]
+            alerts_to_fire = decision.alerts_to_fire
+            if alerts_to_fire and notifiers:
+                alert_diffs = [(n, d) for n, d in diffs if n in alerts_to_fire]
                 analysis = _analyze_check_diffs(diffs)
+                incident = detect_coordinated_incident(alert_diffs)
                 for label, notifier in notifiers:
-                    asyncio.run(notifier.send_regression_alert(alert_diffs, analysis))
+                    asyncio.run(
+                        notifier.send_regression_alert(
+                            alert_diffs, analysis, incident=incident
+                        )
+                    )
                     alerts_sent += 1
 
             spike_alerts = _detect_spikes(results, golden_traces, cost_threshold, latency_threshold)

--- a/evalview/commands/slack_digest_cmd.py
+++ b/evalview/commands/slack_digest_cmd.py
@@ -39,6 +39,7 @@ from evalview.commands.since_cmd import (
     _parse_since,
     _summarize,
 )
+from evalview.core.noise_tracker import NoiseStats, load_noise_stats
 from evalview.telemetry.decorators import track_command
 
 
@@ -54,12 +55,21 @@ def _build_message(
     window: Dict[str, Any],
     drift_rows: List[Any],
     stale_quarantine: List[Dict[str, Any]],
+    noise_stats: Optional[NoiseStats] = None,
 ) -> Dict[str, Any]:
     """Build a Slack `blocks` message matching the Slack block-kit schema.
 
     Pure function — no I/O, easy to unit-test. Returns the JSON payload
     ready to POST. We use blocks rather than plain markdown so the
     message renders cleanly on desktop, mobile, and Slack search.
+
+    Args:
+        noise_stats: Optional aggregated noise counters over the window.
+            When present, a "Noise" section is rendered that publicly
+            reports alerts fired vs. suppressed — the point is to hold
+            ourselves accountable for false-positive rate rather than
+            hide it. If the stats are empty (no alert activity in the
+            window), the section is skipped so the digest stays tight.
     """
     pass_rate = window.get("pass_rate")
     total = window.get("total", 0)
@@ -113,6 +123,41 @@ def _build_message(
                 "text": {
                     "type": "mrkdwn",
                     "text": "*Drift*\n" + "\n".join(drift_lines),
+                },
+            }
+        )
+
+    # Noise block — public false-positive rate. We render this before
+    # stale quarantine because it's the meta-metric users should glance
+    # at first; a noisy product is a distrusted product, and the digest
+    # is the right place to hold ourselves visible to it.
+    if noise_stats is not None and (
+        noise_stats.alerts_fired + noise_stats.suppressed > 0
+    ):
+        fpr = noise_stats.false_positive_rate
+        if fpr is None:
+            noise_headline = "No alert activity."
+        else:
+            pct = int(round(fpr * 100))
+            if pct <= 5:
+                emoji_noise = "🟢"
+            elif pct <= 20:
+                emoji_noise = "🟡"
+            else:
+                emoji_noise = "🔴"
+            noise_headline = (
+                f"{emoji_noise} "
+                f"{noise_stats.alerts_fired} fired · "
+                f"{noise_stats.real_alerts} real · "
+                f"{noise_stats.suppressed} suppressed "
+                f"({pct}% noise)"
+            )
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Noise*\n{noise_headline}",
                 },
             }
         )
@@ -272,7 +317,13 @@ def slack_digest_cmd(
     except Exception:
         pass
 
-    payload = _build_message(label, window, drift_rows, stale_quarantine)
+    # Load noise stats over the same window as `_summarize` so the
+    # "X% noise" line is consistent with the other digest numbers.
+    noise_stats = load_noise_stats(since=cutoff_dt)
+
+    payload = _build_message(
+        label, window, drift_rows, stale_quarantine, noise_stats=noise_stats
+    )
 
     if dry_run:
         console.print("[bold]Slack payload preview:[/bold]")

--- a/evalview/commands/slack_digest_cmd.py
+++ b/evalview/commands/slack_digest_cmd.py
@@ -131,6 +131,11 @@ def _build_message(
     # stale quarantine because it's the meta-metric users should glance
     # at first; a noisy product is a distrusted product, and the digest
     # is the right place to hold ourselves visible to it.
+    #
+    # Critically, we ALSO render the list of tests that were silently
+    # suppressed, so "suppression" never becomes "hidden signal". The
+    # user can still see which tests self-resolved and decide whether
+    # the gate was right or whether something deeper is wrong.
     if noise_stats is not None and (
         noise_stats.alerts_fired + noise_stats.suppressed > 0
     ):
@@ -152,12 +157,32 @@ def _build_message(
                 f"{noise_stats.suppressed} suppressed "
                 f"({pct}% noise)"
             )
+
+        noise_text = f"*Noise*\n{noise_headline}"
+
+        if noise_stats.suppressed_by_test:
+            # Show the top-5 most-suppressed tests so the user can spot
+            # patterns — a test that self-resolved 4 times this week is
+            # no longer a flake, it's a signal. Keep the list bounded
+            # so the digest doesn't become its own firehose.
+            top = noise_stats.suppressed_by_test[:5]
+            lines = [
+                "_Suppressed (self-resolved before confirming):_",
+            ]
+            for entry in top:
+                count_str = f"× {entry.count}" if entry.count > 1 else ""
+                lines.append(f"• `{entry.test_name}` {count_str}".rstrip())
+            if len(noise_stats.suppressed_by_test) > 5:
+                extra = len(noise_stats.suppressed_by_test) - 5
+                lines.append(f"…and {extra} more")
+            noise_text += "\n" + "\n".join(lines)
+
         blocks.append(
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"*Noise*\n{noise_headline}",
+                    "text": noise_text,
                 },
             }
         )

--- a/evalview/core/discord_notifier.py
+++ b/evalview/core/discord_notifier.py
@@ -1,6 +1,6 @@
 """Discord webhook notifier for EvalView monitor alerts."""
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 import logging
 
 import httpx
@@ -18,10 +18,43 @@ class DiscordNotifier:
         self,
         diffs: List[Tuple[str, Any]],
         analysis: Dict[str, Any],
+        incident: Optional[Any] = None,
     ) -> bool:
-        """Send a regression alert to Discord."""
+        """Send a regression alert to Discord.
+
+        When `incident` is provided, multiple correlated failures are
+        collapsed into a single incident card — see `SlackNotifier` for
+        the full rationale.
+        """
         from evalview.core.diff import DiffStatus
         from evalview.core.root_cause import analyze_root_cause
+
+        total = len(diffs)
+        passed = sum(1 for _, d in diffs if d.overall_severity == DiffStatus.PASSED)
+
+        if incident is not None:
+            affected_lines = "\n".join(
+                f"• {name}" for name in incident.affected[:10]
+            )
+            more = ""
+            if len(incident.affected) > 10:
+                more = f"\n…and {len(incident.affected) - 10} more"
+            text = (
+                ":rotating_light: **EvalView Monitor - Incident**\n\n"
+                f"**{incident.headline}**\n"
+                f"{passed}/{total} tests passing\n\n"
+                f"{affected_lines}{more}\n\n"
+                "Run `evalview check` for full details - "
+                "investigate provider/runtime change before tweaking the agent."
+            )
+            try:
+                async with httpx.AsyncClient(timeout=10.0) as client:
+                    resp = await client.post(self.webhook_url, json={"content": text})
+                    resp.raise_for_status()
+                    return True
+            except Exception as e:
+                logger.warning("Discord notification failed: %s", e)
+                return False
 
         failing = []
         for name, diff in diffs:
@@ -38,9 +71,6 @@ class DiscordNotifier:
 
         if not failing:
             return True
-
-        total = len(diffs)
-        passed = sum(1 for _, d in diffs if d.overall_severity == DiffStatus.PASSED)
 
         text = (
             ":warning: **EvalView Monitor - Regression Detected**\n\n"

--- a/evalview/core/noise_tracker.py
+++ b/evalview/core/noise_tracker.py
@@ -1,0 +1,427 @@
+"""Noise tracking and confirmation gates for alerts.
+
+This module implements three pieces of the "less noisy product" design:
+
+1. **Confirmation gate (n>=2)** — a failure seen in a single cycle is never
+   enough to alert a human. `ConfirmationGate` tracks which failures have been
+   "pending" for one cycle and promotes them to "confirmed" only when they
+   re-fail in the next cycle. A pending failure that self-resolves is counted
+   as a suppressed false positive.
+
+2. **Coordinated incident detection** — when multiple tests fail together in
+   the same cycle and share a common root cause (model change, runtime
+   fingerprint shift, or simply large batch correlation), they collapse into
+   a single incident. `detect_coordinated_incident` returns either an
+   `Incident` describing the shared cause, or None to fall back to per-test
+   line items.
+
+3. **Public noise metric** — the `NoiseStats` dataclass holds the counters we
+   persist to `.evalview/noise.jsonl` so `evalview slack-digest` can render
+   a "this week: X alerts, Y real (Z% noise)" line with verifiable math.
+
+Every alert is a promise. If 1 in 5 is a false alarm, users start ignoring
+all of them. Optimize directly for "every alert that fires is one the user
+is glad fired."
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# The default root a confirmation gate / noise log sits under. Callers can
+# override for tests. We deliberately do not import from elsewhere in the
+# package to keep this module dependency-free and cheap to unit-test.
+_DEFAULT_BASE = Path(".") / ".evalview"
+_NOISE_LOG = "noise.jsonl"
+
+
+# ─────────────────────────── confirmation gate ───────────────────────────
+
+
+@dataclass
+class GateDecision:
+    """Result of running a cycle's failures through the confirmation gate.
+
+    Attributes:
+        confirmed: Tests that failed this cycle AND the previous cycle.
+                   These are the only tests the caller should alert on.
+        pending: Tests that failed this cycle for the first time. No alert
+                 should fire for these — they wait for the next cycle.
+        self_resolved: Tests that were pending from the previous cycle but
+                       passed this cycle. These are counted as suppressed
+                       false positives in the noise metric.
+        carried_forward: Tests that were confirmed in an earlier cycle and
+                         are still failing. Not re-alerted (already alerted
+                         on first confirmation).
+    """
+
+    confirmed: Set[str] = field(default_factory=set)
+    pending: Set[str] = field(default_factory=set)
+    self_resolved: Set[str] = field(default_factory=set)
+    carried_forward: Set[str] = field(default_factory=set)
+
+    @property
+    def alerts_to_fire(self) -> Set[str]:
+        """The tests whose status should actually page a human this cycle."""
+        return set(self.confirmed)
+
+
+@dataclass
+class ConfirmationGate:
+    """State machine that suppresses n=1 alerts.
+
+    The gate owns three sets of test names between cycles:
+
+        pending           — failed once, waiting for confirmation
+        confirmed_alerted — failed twice in a row, already alerted
+        (everything else) — currently passing
+
+    A single call to `evaluate(currently_failing)` advances the machine
+    by one cycle and returns a `GateDecision` describing what changed.
+    The caller fires alerts only for `decision.confirmed`, and records
+    `decision.self_resolved` as suppressed false positives.
+    """
+
+    pending: Set[str] = field(default_factory=set)
+    confirmed_alerted: Set[str] = field(default_factory=set)
+
+    def evaluate(self, currently_failing: Iterable[str]) -> GateDecision:
+        """Advance the gate by one cycle.
+
+        Args:
+            currently_failing: Set of test names that failed this cycle.
+
+        Returns:
+            GateDecision describing which tests were promoted to confirmed
+            (and therefore should alert), which are still pending, and
+            which self-resolved without alerting.
+        """
+        currently = set(currently_failing)
+
+        # Pending tests that passed this cycle → self-resolved (false positive).
+        self_resolved = self.pending - currently
+
+        # Previously pending AND still failing → promote to confirmed.
+        # These are the ones that actually fire alerts.
+        newly_confirmed = self.pending & currently
+
+        # Previously confirmed AND still failing → carry forward silently.
+        # We already alerted on the first confirmation; don't re-page.
+        still_confirmed = self.confirmed_alerted & currently
+
+        # Currently failing, but neither pending nor previously confirmed →
+        # brand-new failures. These become pending for *next* cycle.
+        new_pending = currently - self.pending - self.confirmed_alerted
+
+        # Confirmed tests that recovered → drop from confirmed set.
+        # They'll trigger the existing recovery-alert path in the caller.
+        # (The caller owns the recovery alert; we just clean up state.)
+        #
+        # We intentionally do NOT track recoveries here — that's the
+        # caller's job via its own previously_failing set.
+
+        decision = GateDecision(
+            confirmed=newly_confirmed,
+            pending=new_pending,
+            self_resolved=self_resolved,
+            carried_forward=still_confirmed,
+        )
+
+        # Update the gate's state for the next cycle.
+        self.pending = new_pending
+        self.confirmed_alerted = newly_confirmed | still_confirmed
+
+        return decision
+
+
+# ─────────────────────────── coordinated incidents ───────────────────────────
+
+
+@dataclass
+class Incident:
+    """A collapsed view of many correlated failures.
+
+    When 5 tests fail in the same cycle because `gpt-5.1` rolled out,
+    we want ONE Slack card that says "5 tests shifted together — likely
+    provider update," not five line items that create five separate
+    moments of panic.
+
+    Attributes:
+        cause: Short human label, e.g. "likely provider update".
+        confidence: "low" | "medium" | "high".
+        affected: Sorted list of test names involved.
+        evidence: Free-form dict of the signals that led to this grouping,
+                  surfaced in the Slack card's details section.
+    """
+
+    cause: str
+    confidence: str
+    affected: List[str]
+    evidence: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def headline(self) -> str:
+        """Single-sentence summary for Slack/PR cards."""
+        n = len(self.affected)
+        plural = "s" if n != 1 else ""
+        return (
+            f"{n} test{plural} shifted together — "
+            f"{self.cause} (confidence: {self.confidence})"
+        )
+
+
+def detect_coordinated_incident(
+    diffs: List[Tuple[str, Any]],
+    min_affected: int = 3,
+) -> Optional[Incident]:
+    """Detect whether a batch of failures shares a common root cause.
+
+    The collapse rules are deliberately conservative — we'd rather leave
+    a real incident uncollapsed than wrongly merge unrelated failures.
+
+    Rules, in order:
+
+      1. If ≥ `min_affected` failing tests all report `model_changed=True`,
+         classify as "likely provider update" at HIGH confidence.
+      2. If ≥ `min_affected` failing tests share the same runtime model
+         fingerprint that differs from baseline, classify as "runtime
+         fingerprint shift" at MEDIUM confidence.
+      3. If ≥ `min_affected` failing tests exist in the same batch but
+         have no shared signal, classify as "correlated batch failure"
+         at LOW confidence — still a useful hint that something
+         infrastructure-level moved, but we don't claim to know what.
+
+    Returns None if no rule triggers. In that case the caller renders
+    per-test line items as usual.
+    """
+    if len(diffs) < min_affected:
+        return None
+
+    # Only look at failing diffs — a coordinated incident is about the
+    # failures, not the whole suite.
+    from evalview.core.diff import DiffStatus
+
+    failing: List[Tuple[str, Any]] = [
+        (name, diff)
+        for name, diff in diffs
+        if getattr(diff, "overall_severity", None) != DiffStatus.PASSED
+    ]
+
+    if len(failing) < min_affected:
+        return None
+
+    # Rule 1: declared model change across multiple tests.
+    model_changed_tests = [
+        name for name, diff in failing if getattr(diff, "model_changed", False)
+    ]
+    if len(model_changed_tests) >= min_affected:
+        return Incident(
+            cause="likely provider update",
+            confidence="high",
+            affected=sorted(model_changed_tests),
+            evidence={
+                "signal": "model_changed_flag",
+                "count": len(model_changed_tests),
+                "total_failing": len(failing),
+            },
+        )
+
+    # Rule 2: shared runtime fingerprint different from baseline.
+    fingerprints: Dict[str, List[str]] = {}
+    for name, diff in failing:
+        fp = getattr(diff, "runtime_model_fingerprint", None) or getattr(
+            diff, "actual_model_id", None
+        )
+        if fp:
+            fingerprints.setdefault(str(fp), []).append(name)
+
+    for fp, tests in fingerprints.items():
+        if len(tests) >= min_affected:
+            return Incident(
+                cause="runtime fingerprint shift",
+                confidence="medium",
+                affected=sorted(tests),
+                evidence={
+                    "signal": "runtime_fingerprint",
+                    "fingerprint": fp,
+                    "count": len(tests),
+                    "total_failing": len(failing),
+                },
+            )
+
+    # Rule 3: correlated batch with no shared signal. Only fire if the
+    # failing tests are the *majority* of the batch — a random one-test
+    # regression in a 100-test suite should not trigger this.
+    if len(failing) >= min_affected and len(failing) >= max(
+        min_affected, len(diffs) // 2
+    ):
+        return Incident(
+            cause="correlated batch failure",
+            confidence="low",
+            affected=sorted(name for name, _ in failing),
+            evidence={
+                "signal": "batch_correlation",
+                "failing": len(failing),
+                "total": len(diffs),
+            },
+        )
+
+    return None
+
+
+# ─────────────────────────── public noise metric ───────────────────────────
+
+
+@dataclass
+class NoiseStats:
+    """Rolling counters for the public "noise" metric.
+
+    These are aggregated from `.evalview/noise.jsonl` across a time window
+    and rendered in the Slack digest as:
+
+        "This week: 12 alerts fired · 9 real · 3 suppressed (25% noise)"
+
+    Fields:
+        alerts_fired: Number of times an alert was actually sent to a
+                      notifier (not including suppressed n=1 failures).
+        real_alerts: Alerts that stayed failing in a subsequent cycle —
+                     "confirmed real" by the gate downstream.
+        suppressed: Failures that were pending but self-resolved before
+                    ever becoming an alert. The gate saved the user from
+                    these.
+    """
+
+    alerts_fired: int = 0
+    real_alerts: int = 0
+    suppressed: int = 0
+
+    @property
+    def false_positive_rate(self) -> Optional[float]:
+        """Suppressed / (suppressed + alerts_fired). None if no signal yet.
+
+        This is the *pre-alert* false-positive rate — how often a raw
+        failure would have paged someone without the confirmation gate.
+        A number close to 0 means the agent is stable; a number close
+        to 1 means the gate is doing heavy lifting and real alerts are
+        rare.
+        """
+        denom = self.alerts_fired + self.suppressed
+        if denom == 0:
+            return None
+        return self.suppressed / denom
+
+    def format_line(self) -> str:
+        """Render as a one-line digest string."""
+        fpr = self.false_positive_rate
+        if fpr is None:
+            return "No alert activity in this window."
+        pct = int(round(fpr * 100))
+        return (
+            f"{self.alerts_fired} alerts fired · "
+            f"{self.real_alerts} real · "
+            f"{self.suppressed} suppressed ({pct}% noise)"
+        )
+
+
+def record_cycle_noise(
+    decision: GateDecision,
+    base_path: Optional[Path] = None,
+    timestamp: Optional[datetime] = None,
+) -> None:
+    """Append one cycle's noise counters to `.evalview/noise.jsonl`.
+
+    Called by the monitor loop after every cycle. Each line records:
+        - alerts_fired:  number of confirmed failures that fired alerts
+        - real_alerts:   same as alerts_fired (every confirmed firing is
+                         real by definition of the gate)
+        - suppressed:    number of self-resolved pendings this cycle
+        - pending_count: number of pendings carried into next cycle
+                         (diagnostic only, not part of the public metric)
+
+    Writes are best-effort — a failed write logs a warning and returns.
+    The monitor loop must never crash because the noise log is unwritable.
+    """
+    base = base_path or _DEFAULT_BASE
+    path = base / _NOISE_LOG
+    ts = timestamp or datetime.now(timezone.utc)
+
+    record = {
+        "ts": ts.isoformat(),
+        "alerts_fired": len(decision.confirmed),
+        "real_alerts": len(decision.confirmed),
+        "suppressed": len(decision.self_resolved),
+        "pending_count": len(decision.pending),
+    }
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError as exc:
+        logger.warning("Failed to write noise log: %s", exc)
+
+
+def load_noise_stats(
+    base_path: Optional[Path] = None,
+    since: Optional[datetime] = None,
+) -> NoiseStats:
+    """Read `.evalview/noise.jsonl` and sum counters over a time window.
+
+    Args:
+        base_path: Project root containing `.evalview/`. Defaults to CWD.
+        since: Only include records newer than this datetime. If None,
+               include all records in the file.
+
+    Returns:
+        NoiseStats with totals over the window. Zero values if the file
+        doesn't exist or is empty — callers must handle that case
+        gracefully (the digest shows "no activity" rather than "0% noise",
+        which would be misleading).
+    """
+    base = base_path or _DEFAULT_BASE
+    path = base / _NOISE_LOG
+    stats = NoiseStats()
+
+    if not path.exists():
+        return stats
+
+    try:
+        with path.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                if since is not None:
+                    ts_raw = record.get("ts")
+                    if ts_raw:
+                        try:
+                            ts = datetime.fromisoformat(str(ts_raw))
+                            if ts.tzinfo is None:
+                                ts = ts.replace(tzinfo=timezone.utc)
+                            if ts <= since:
+                                continue
+                        except ValueError:
+                            # Malformed timestamp — include by default
+                            # rather than silently drop.
+                            pass
+
+                stats.alerts_fired += int(record.get("alerts_fired", 0) or 0)
+                stats.real_alerts += int(record.get("real_alerts", 0) or 0)
+                stats.suppressed += int(record.get("suppressed", 0) or 0)
+    except OSError as exc:
+        logger.warning("Failed to read noise log: %s", exc)
+        return NoiseStats()
+
+    return stats

--- a/evalview/core/noise_tracker.py
+++ b/evalview/core/noise_tracker.py
@@ -50,8 +50,9 @@ class GateDecision:
     """Result of running a cycle's failures through the confirmation gate.
 
     Attributes:
-        confirmed: Tests that failed this cycle AND the previous cycle.
-                   These are the only tests the caller should alert on.
+        confirmed: Tests that failed this cycle AND the previous cycle
+                   (or failed once while marked strict). These are the
+                   tests the caller should alert on.
         pending: Tests that failed this cycle for the first time. No alert
                  should fire for these — they wait for the next cycle.
         self_resolved: Tests that were pending from the previous cycle but
@@ -60,17 +61,23 @@ class GateDecision:
         carried_forward: Tests that were confirmed in an earlier cycle and
                          are still failing. Not re-alerted (already alerted
                          on first confirmation).
+        strict_immediate: Tests in the strict bypass set that failed this
+                          cycle. They are rolled into `confirmed` so the
+                          caller alerts on them, but tracked separately so
+                          the caller can log "strict: bypassing gate" and
+                          so tests can verify the bypass actually fired.
     """
 
     confirmed: Set[str] = field(default_factory=set)
     pending: Set[str] = field(default_factory=set)
     self_resolved: Set[str] = field(default_factory=set)
     carried_forward: Set[str] = field(default_factory=set)
+    strict_immediate: Set[str] = field(default_factory=set)
 
     @property
     def alerts_to_fire(self) -> Set[str]:
         """The tests whose status should actually page a human this cycle."""
-        return set(self.confirmed)
+        return set(self.confirmed) | set(self.strict_immediate)
 
 
 @dataclass
@@ -92,49 +99,70 @@ class ConfirmationGate:
     pending: Set[str] = field(default_factory=set)
     confirmed_alerted: Set[str] = field(default_factory=set)
 
-    def evaluate(self, currently_failing: Iterable[str]) -> GateDecision:
+    def evaluate(
+        self,
+        currently_failing: Iterable[str],
+        strict: Optional[Iterable[str]] = None,
+    ) -> GateDecision:
         """Advance the gate by one cycle.
 
         Args:
             currently_failing: Set of test names that failed this cycle.
+            strict: Names of tests marked `gate: strict` in their YAML —
+                these bypass the confirmation gate entirely. A strict
+                test that fails even once alerts immediately, without
+                waiting for a second cycle to confirm. Use this for
+                safety-critical behaviors (auth, payments, PII, refund
+                paths) where a single false positive is cheaper than
+                missing a real regression for five minutes.
 
         Returns:
             GateDecision describing which tests were promoted to confirmed
-            (and therefore should alert), which are still pending, and
-            which self-resolved without alerting.
+            (and therefore should alert), which strict tests bypassed the
+            gate, which are still pending, and which self-resolved
+            without alerting.
         """
         currently = set(currently_failing)
+        strict_set = set(strict or ())
+
+        # Strict tests bypass the whole state machine: any strict test
+        # failing this cycle alerts immediately. They are NOT recorded
+        # in `pending` or `confirmed_alerted`, because those buckets are
+        # what the relaxed state machine uses to avoid re-alerting — and
+        # strict tests should re-alert every cycle they stay broken so
+        # the user can't accidentally forget about them.
+        strict_firing = currently & strict_set
+
+        # For the relaxed-mode logic below we only consider the subset
+        # of failures that are NOT strict. This keeps the buckets clean.
+        relaxed_currently = currently - strict_set
 
         # Pending tests that passed this cycle → self-resolved (false positive).
-        self_resolved = self.pending - currently
+        self_resolved = self.pending - relaxed_currently
 
         # Previously pending AND still failing → promote to confirmed.
         # These are the ones that actually fire alerts.
-        newly_confirmed = self.pending & currently
+        newly_confirmed = self.pending & relaxed_currently
 
         # Previously confirmed AND still failing → carry forward silently.
         # We already alerted on the first confirmation; don't re-page.
-        still_confirmed = self.confirmed_alerted & currently
+        still_confirmed = self.confirmed_alerted & relaxed_currently
 
         # Currently failing, but neither pending nor previously confirmed →
         # brand-new failures. These become pending for *next* cycle.
-        new_pending = currently - self.pending - self.confirmed_alerted
-
-        # Confirmed tests that recovered → drop from confirmed set.
-        # They'll trigger the existing recovery-alert path in the caller.
-        # (The caller owns the recovery alert; we just clean up state.)
-        #
-        # We intentionally do NOT track recoveries here — that's the
-        # caller's job via its own previously_failing set.
+        new_pending = relaxed_currently - self.pending - self.confirmed_alerted
 
         decision = GateDecision(
             confirmed=newly_confirmed,
             pending=new_pending,
             self_resolved=self_resolved,
             carried_forward=still_confirmed,
+            strict_immediate=strict_firing,
         )
 
-        # Update the gate's state for the next cycle.
+        # Update the gate's state for the next cycle. Strict tests are
+        # excluded from the internal buckets so they keep alerting every
+        # cycle until they pass.
         self.pending = new_pending
         self.confirmed_alerted = newly_confirmed | still_confirmed
 
@@ -280,6 +308,25 @@ def detect_coordinated_incident(
 
 
 @dataclass
+class SuppressedEntry:
+    """Per-test summary of unconfirmed failures the gate swallowed.
+
+    The digest uses this to render a visible list of "what got
+    suppressed this week" so the user can sanity-check the gate's
+    decisions — never hide the signal, just the alert.
+
+    Attributes:
+        test_name: Name of the test that self-resolved.
+        count: How many times it self-resolved in the window.
+        last_seen: ISO-8601 timestamp of the most recent suppression.
+    """
+
+    test_name: str
+    count: int = 0
+    last_seen: Optional[str] = None
+
+
+@dataclass
 class NoiseStats:
     """Rolling counters for the public "noise" metric.
 
@@ -296,11 +343,17 @@ class NoiseStats:
         suppressed: Failures that were pending but self-resolved before
                     ever becoming an alert. The gate saved the user from
                     these.
+        suppressed_by_test: Per-test breakdown so the digest can render
+                    "Suppressed this week: flaky-search ×3, auth-retry ×1"
+                    with last-seen timestamps. Keeping this as a list
+                    rather than a dict preserves ordering for rendering
+                    (most recent / highest count first).
     """
 
     alerts_fired: int = 0
     real_alerts: int = 0
     suppressed: int = 0
+    suppressed_by_test: List[SuppressedEntry] = field(default_factory=list)
 
     @property
     def false_positive_rate(self) -> Optional[float]:
@@ -338,12 +391,20 @@ def record_cycle_noise(
     """Append one cycle's noise counters to `.evalview/noise.jsonl`.
 
     Called by the monitor loop after every cycle. Each line records:
-        - alerts_fired:  number of confirmed failures that fired alerts
-        - real_alerts:   same as alerts_fired (every confirmed firing is
-                         real by definition of the gate)
-        - suppressed:    number of self-resolved pendings this cycle
-        - pending_count: number of pendings carried into next cycle
-                         (diagnostic only, not part of the public metric)
+        - alerts_fired:     number of alerts that fired this cycle
+                            (confirmed + strict_immediate)
+        - real_alerts:      same as alerts_fired — every fired alert is
+                            real by definition of the gate
+        - suppressed:       number of self-resolved pendings this cycle
+        - pending_count:    number of pendings carried into next cycle
+                            (diagnostic only, not part of the public metric)
+        - suppressed_tests: *names* of the tests that self-resolved,
+                            so the digest can show the user WHICH tests
+                            were suppressed, not just a count. This is
+                            critical: suppressing the alert is fine,
+                            suppressing the signal is not.
+        - strict_tests:     names of tests that fired via strict bypass,
+                            so the audit trail records the reason.
 
     Writes are best-effort — a failed write logs a warning and returns.
     The monitor loop must never crash because the noise log is unwritable.
@@ -352,12 +413,15 @@ def record_cycle_noise(
     path = base / _NOISE_LOG
     ts = timestamp or datetime.now(timezone.utc)
 
+    alerts_fired = len(decision.confirmed) + len(decision.strict_immediate)
     record = {
         "ts": ts.isoformat(),
-        "alerts_fired": len(decision.confirmed),
-        "real_alerts": len(decision.confirmed),
+        "alerts_fired": alerts_fired,
+        "real_alerts": alerts_fired,
         "suppressed": len(decision.self_resolved),
         "pending_count": len(decision.pending),
+        "suppressed_tests": sorted(decision.self_resolved),
+        "strict_tests": sorted(decision.strict_immediate),
     }
 
     try:
@@ -392,6 +456,10 @@ def load_noise_stats(
     if not path.exists():
         return stats
 
+    # Per-test aggregation — used to populate suppressed_by_test.
+    # {test_name: (count, last_seen_ts_iso)}
+    per_test: Dict[str, Tuple[int, str]] = {}
+
     try:
         with path.open(encoding="utf-8") as f:
             for line in f:
@@ -420,8 +488,27 @@ def load_noise_stats(
                 stats.alerts_fired += int(record.get("alerts_fired", 0) or 0)
                 stats.real_alerts += int(record.get("real_alerts", 0) or 0)
                 stats.suppressed += int(record.get("suppressed", 0) or 0)
+
+                # Aggregate per-test suppression counts so we can surface
+                # "WHICH tests got silently suppressed" in the digest.
+                ts_str = str(record.get("ts") or "")
+                for name in record.get("suppressed_tests") or []:
+                    prev_count, prev_ts = per_test.get(str(name), (0, ""))
+                    # Keep the lexicographically-later (≈ most recent) ts
+                    new_ts = ts_str if ts_str > prev_ts else prev_ts
+                    per_test[str(name)] = (prev_count + 1, new_ts)
     except OSError as exc:
         logger.warning("Failed to read noise log: %s", exc)
         return NoiseStats()
+
+    # Sort by (count desc, most recent first) so the digest leads with
+    # the tests a user would most want to look at.
+    stats.suppressed_by_test = [
+        SuppressedEntry(test_name=name, count=count, last_seen=last_seen)
+        for name, (count, last_seen) in sorted(
+            per_test.items(),
+            key=lambda kv: (-kv[1][0], kv[0]),
+        )
+    ]
 
     return stats

--- a/evalview/core/slack_notifier.py
+++ b/evalview/core/slack_notifier.py
@@ -1,6 +1,6 @@
 """Slack webhook notifier for EvalView monitor alerts."""
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 import logging
 
 import httpx
@@ -18,12 +18,20 @@ class SlackNotifier:
         self,
         diffs: List[Tuple[str, Any]],
         analysis: Dict[str, Any],
+        incident: Optional[Any] = None,
     ) -> bool:
         """Send a regression alert to Slack.
 
         Args:
             diffs: List of (test_name, TraceDiff) tuples.
             analysis: Output of _analyze_check_diffs.
+            incident: Optional `noise_tracker.Incident` collapsing several
+                      correlated failures into a single card. When present,
+                      the message leads with the incident headline and
+                      includes a concise list of affected tests, instead
+                      of a per-test line item for each failure. This is
+                      the "dedupe by root cause" behaviour — one Slack
+                      ping for "12 tests shifted together," not twelve.
 
         Returns:
             True if the message was sent successfully.
@@ -31,7 +39,32 @@ class SlackNotifier:
         from evalview.core.diff import DiffStatus
         from evalview.core.root_cause import analyze_root_cause
 
-        # Build the list of failing tests
+        total = len(diffs)
+        passed = sum(1 for _, d in diffs if d.overall_severity == DiffStatus.PASSED)
+
+        # Incident-collapsed path: one headline, a short list of affected
+        # tests, and a single next-step. We deliberately do NOT emit a
+        # per-test root-cause line here — the whole point is that the
+        # shared cause is already in the headline.
+        if incident is not None:
+            affected_lines = "\n".join(
+                f"• {name}" for name in incident.affected[:10]
+            )
+            more = ""
+            if len(incident.affected) > 10:
+                more = f"\n…and {len(incident.affected) - 10} more"
+            text = (
+                f":rotating_light: *EvalView Monitor — Incident*\n\n"
+                f"*{incident.headline}*\n"
+                f"{passed}/{total} tests passing\n\n"
+                f"{affected_lines}{more}\n\n"
+                f"_Run `evalview check` for full details — "
+                f"investigate provider/runtime change before tweaking the agent._"
+            )
+            payload = {"text": text}
+            return await self._post(payload)
+
+        # Per-test line-item path (uncollapsed) — unchanged from before.
         failing = []
         for name, diff in diffs:
             root_cause = analyze_root_cause(diff)
@@ -48,9 +81,6 @@ class SlackNotifier:
         if not failing:
             return True  # Nothing to report
 
-        total = len(diffs)
-        passed = sum(1 for _, d in diffs if d.overall_severity == DiffStatus.PASSED)
-
         text = (
             f":warning: *EvalView Monitor — Regression Detected*\n\n"
             f"{passed}/{total} tests passing\n\n"
@@ -59,7 +89,15 @@ class SlackNotifier:
         )
 
         payload = {"text": text}
+        return await self._post(payload)
 
+    async def _post(self, payload: Dict[str, Any]) -> bool:
+        """POST a payload to the configured Slack webhook.
+
+        Extracted so incident-collapsed and per-test code paths share the
+        same transport. Never raises — Slack outages should never break
+        CI pipelines that trigger the monitor.
+        """
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
                 resp = await client.post(self.webhook_url, json=payload)

--- a/evalview/core/types.py
+++ b/evalview/core/types.py
@@ -214,6 +214,21 @@ class TestCase(BaseModel):
         description="Behavior tags for filtering and grouped reporting."
     )
 
+    # Optional: confirmation-gate mode. Default is "relaxed", meaning a
+    # failure must persist into a second monitor cycle before it fires an
+    # alert — this suppresses single-cycle flakes. Set to "strict" for
+    # safety-critical tests (auth, payments, PII, refund flows, etc.)
+    # where even a one-cycle blip is worth investigating immediately.
+    # Strict tests bypass the ConfirmationGate and alert on n=1.
+    gate: Optional[str] = Field(
+        default=None,
+        description=(
+            "Confirmation-gate mode: 'strict' (alert on n=1, bypass the "
+            "gate — use for safety-critical tests) or omit/None for "
+            "relaxed (wait one cycle to confirm before alerting)."
+        ),
+    )
+
     # Set to True by evalview init auto-generation. Never set by users.
     # Enables strict quality gating — generated tests with bad queries are
     # skipped before running so they don't pollute agent scores.

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -317,6 +317,52 @@ class TestSlackNotifier:
         assert "All Clear" in payload["text"]
         assert "5" in payload["text"]
 
+    def test_regression_alert_collapses_incident_into_single_card(self):
+        """When 3+ tests fail together with a shared root cause, the
+        notifier should emit ONE incident card — not three individual
+        line items. This is the user-facing payoff of dedupe-by-root-cause."""
+        from evalview.core.noise_tracker import Incident
+
+        notifier = SlackNotifier("https://hooks.slack.com/test")
+
+        diff_a = _make_diff("REGRESSION", score_diff=-20.0)
+        diff_b = _make_diff("REGRESSION", score_diff=-15.0)
+        diff_c = _make_diff("REGRESSION", score_diff=-10.0)
+        diffs = [("test-a", diff_a), ("test-b", diff_b), ("test-c", diff_c)]
+
+        incident = Incident(
+            cause="likely provider update",
+            confidence="high",
+            affected=["test-a", "test-b", "test-c"],
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status = MagicMock()
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = asyncio.run(
+                notifier.send_regression_alert(diffs, {}, incident=incident)
+            )
+
+        assert result is True
+        call_args = mock_client.post.call_args
+        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        text = payload["text"]
+        # Must include the incident headline, not per-test REGRESSION
+        # line items.
+        assert "likely provider update" in text
+        assert "3 tests shifted together" in text
+        assert "Incident" in text
+        # All affected tests should still appear as a short list.
+        assert "test-a" in text
+        assert "test-b" in text
+        assert "test-c" in text
+
     def test_empty_diffs_returns_true(self):
         """No failing tests should return True without sending."""
         notifier = SlackNotifier("https://hooks.slack.com/test")

--- a/tests/test_noise_tracker.py
+++ b/tests/test_noise_tracker.py
@@ -1,0 +1,296 @@
+"""Tests for the confirmation gate, incident collapse, and noise metric.
+
+These three pieces together deliver the "less noisy product" initiative:
+
+    1. ConfirmationGate: no alert ever fires on n=1.
+    2. detect_coordinated_incident: many correlated failures collapse
+       into one incident card.
+    3. NoiseStats / record_cycle_noise / load_noise_stats: publicly
+       reported false-positive rate that the gate is saving users from.
+
+The tests below pin down the exact state machine so future refactors
+can't silently break the user-facing promise of "we don't page you
+until we're sure."
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from evalview.core.diff import DiffStatus
+from evalview.core.noise_tracker import (
+    ConfirmationGate,
+    GateDecision,
+    Incident,
+    NoiseStats,
+    detect_coordinated_incident,
+    load_noise_stats,
+    record_cycle_noise,
+)
+
+
+# ─────────────────────────── helpers ───────────────────────────
+
+
+def _make_diff(
+    severity: DiffStatus,
+    *,
+    model_changed: bool = False,
+    fingerprint: str | None = None,
+    actual_model_id: str | None = None,
+):
+    """Build a minimal diff-like object that exposes the fields the
+    incident detector inspects. Using a plain MagicMock keeps the test
+    decoupled from the real TraceDiff class — which would otherwise
+    drag in the whole evaluator pipeline just to check one boolean."""
+    diff = MagicMock()
+    diff.overall_severity = severity
+    diff.model_changed = model_changed
+    diff.runtime_model_fingerprint = fingerprint
+    diff.actual_model_id = actual_model_id
+    return diff
+
+
+# ─────────────────────────── confirmation gate ───────────────────────────
+
+
+class TestConfirmationGate:
+    """The gate must never promote a failure to an alert on the first sighting."""
+
+    def test_first_failure_becomes_pending_not_confirmed(self):
+        gate = ConfirmationGate()
+        decision = gate.evaluate({"billing-flow"})
+        # First time we see it — should go pending, not alert.
+        assert decision.confirmed == set()
+        assert decision.pending == {"billing-flow"}
+        assert decision.alerts_to_fire == set()
+
+    def test_failure_confirmed_on_second_consecutive_cycle(self):
+        gate = ConfirmationGate()
+        gate.evaluate({"billing-flow"})  # cycle 1 → pending
+        decision = gate.evaluate({"billing-flow"})  # cycle 2 → confirmed
+        assert decision.confirmed == {"billing-flow"}
+        assert decision.alerts_to_fire == {"billing-flow"}
+        # After confirmation it leaves the pending bucket.
+        assert decision.pending == set()
+
+    def test_flake_self_resolves_without_alerting(self):
+        """A failure that appears once and disappears must never alert
+        and must be counted as a suppressed false positive — this is
+        the whole point of the gate."""
+        gate = ConfirmationGate()
+        gate.evaluate({"flaky-test"})
+        decision = gate.evaluate(set())  # recovers before confirmation
+        assert decision.confirmed == set()
+        assert decision.self_resolved == {"flaky-test"}
+        assert decision.alerts_to_fire == set()
+
+    def test_no_re_alert_on_persistent_failure(self):
+        gate = ConfirmationGate()
+        gate.evaluate({"billing-flow"})  # pending
+        gate.evaluate({"billing-flow"})  # confirmed → alert fired
+        decision = gate.evaluate({"billing-flow"})  # still failing
+        # Already alerted — do not fire again.
+        assert decision.confirmed == set()
+        assert decision.carried_forward == {"billing-flow"}
+        assert decision.alerts_to_fire == set()
+
+    def test_independent_tests_tracked_separately(self):
+        gate = ConfirmationGate()
+        gate.evaluate({"a"})  # a pending
+        decision = gate.evaluate({"a", "b"})  # a confirmed, b new
+        assert decision.confirmed == {"a"}
+        assert decision.pending == {"b"}
+        assert decision.alerts_to_fire == {"a"}
+
+    def test_mixed_cycle_confirmed_suppressed_and_new(self):
+        """One cycle can simultaneously confirm one, suppress another,
+        and park a third in pending — the state machine has to keep
+        all three buckets straight."""
+        gate = ConfirmationGate()
+        gate.evaluate({"a", "b"})  # both pending
+        decision = gate.evaluate({"a", "c"})
+        # a was pending, failed again → confirmed
+        # b was pending, passed → suppressed
+        # c is new → pending
+        assert decision.confirmed == {"a"}
+        assert decision.self_resolved == {"b"}
+        assert decision.pending == {"c"}
+
+
+# ─────────────────────────── incident detection ───────────────────────────
+
+
+class TestCoordinatedIncident:
+    def test_no_incident_for_single_failure(self):
+        diffs = [("only-one", _make_diff(DiffStatus.REGRESSION))]
+        assert detect_coordinated_incident(diffs) is None
+
+    def test_model_change_across_multiple_tests_high_confidence(self):
+        """3+ failing tests all reporting model_changed should collapse
+        into a HIGH-confidence 'likely provider update' incident — this
+        is the exact 'gpt-5.1 rolled out, 12 alerts became 1' scenario."""
+        diffs = [
+            ("a", _make_diff(DiffStatus.REGRESSION, model_changed=True)),
+            ("b", _make_diff(DiffStatus.REGRESSION, model_changed=True)),
+            ("c", _make_diff(DiffStatus.REGRESSION, model_changed=True)),
+        ]
+        incident = detect_coordinated_incident(diffs)
+        assert incident is not None
+        assert incident.confidence == "high"
+        assert "provider update" in incident.cause
+        assert set(incident.affected) == {"a", "b", "c"}
+        assert "3 test" in incident.headline
+
+    def test_shared_runtime_fingerprint_medium_confidence(self):
+        diffs = [
+            ("a", _make_diff(DiffStatus.REGRESSION, fingerprint="gpt-5.1-2026-04")),
+            ("b", _make_diff(DiffStatus.REGRESSION, fingerprint="gpt-5.1-2026-04")),
+            ("c", _make_diff(DiffStatus.REGRESSION, fingerprint="gpt-5.1-2026-04")),
+        ]
+        incident = detect_coordinated_incident(diffs)
+        assert incident is not None
+        assert incident.confidence == "medium"
+        assert "fingerprint" in incident.cause
+
+    def test_correlated_batch_low_confidence_requires_majority(self):
+        """A batch where the majority of tests fail but share no signal
+        still collapses — but only at LOW confidence, and only when
+        failing is ≥50% of the batch."""
+        diffs = [
+            ("a", _make_diff(DiffStatus.REGRESSION)),
+            ("b", _make_diff(DiffStatus.REGRESSION)),
+            ("c", _make_diff(DiffStatus.REGRESSION)),
+        ]
+        incident = detect_coordinated_incident(diffs)
+        assert incident is not None
+        assert incident.confidence == "low"
+
+    def test_single_failure_in_large_batch_no_incident(self):
+        """One test failing in a 10-test suite should NOT trigger a
+        correlated-batch incident — that's just a normal regression."""
+        diffs = [("bad", _make_diff(DiffStatus.REGRESSION))]
+        diffs.extend(
+            (f"good-{i}", _make_diff(DiffStatus.PASSED)) for i in range(9)
+        )
+        assert detect_coordinated_incident(diffs) is None
+
+    def test_min_affected_threshold_respected(self):
+        diffs = [
+            ("a", _make_diff(DiffStatus.REGRESSION, model_changed=True)),
+            ("b", _make_diff(DiffStatus.REGRESSION, model_changed=True)),
+        ]
+        # Only 2 failures — below default min_affected=3.
+        assert detect_coordinated_incident(diffs) is None
+        # But with a lower threshold it collapses.
+        incident = detect_coordinated_incident(diffs, min_affected=2)
+        assert incident is not None
+        assert incident.confidence == "high"
+
+    def test_incident_headline_format(self):
+        incident = Incident(
+            cause="likely provider update",
+            confidence="high",
+            affected=["a", "b", "c"],
+        )
+        assert incident.headline == (
+            "3 tests shifted together — likely provider update (confidence: high)"
+        )
+
+
+# ─────────────────────────── noise stats + persistence ───────────────────────────
+
+
+class TestNoiseStats:
+    def test_empty_stats_has_no_rate(self):
+        stats = NoiseStats()
+        assert stats.false_positive_rate is None
+        assert "No alert activity" in stats.format_line()
+
+    def test_rate_computation(self):
+        stats = NoiseStats(alerts_fired=8, real_alerts=8, suppressed=2)
+        # 2 suppressed out of 10 total raw failures → 20% noise
+        assert stats.false_positive_rate == pytest.approx(0.2)
+        line = stats.format_line()
+        assert "8 alerts fired" in line
+        assert "8 real" in line
+        assert "2 suppressed" in line
+        assert "20%" in line
+
+    def test_all_noise(self):
+        stats = NoiseStats(alerts_fired=0, real_alerts=0, suppressed=5)
+        # 5/5 → 100% noise — the gate saved the user every single time.
+        assert stats.false_positive_rate == pytest.approx(1.0)
+
+
+class TestNoisePersistence:
+    def test_record_and_load_roundtrip(self, tmp_path):
+        decision = GateDecision(
+            confirmed={"a"},
+            pending={"b"},
+            self_resolved={"c", "d"},
+        )
+        record_cycle_noise(decision, base_path=tmp_path)
+        stats = load_noise_stats(base_path=tmp_path)
+        assert stats.alerts_fired == 1
+        assert stats.real_alerts == 1
+        assert stats.suppressed == 2
+
+    def test_multiple_cycles_aggregate(self, tmp_path):
+        for _ in range(3):
+            record_cycle_noise(
+                GateDecision(confirmed={"x"}, self_resolved={"y"}),
+                base_path=tmp_path,
+            )
+        stats = load_noise_stats(base_path=tmp_path)
+        assert stats.alerts_fired == 3
+        assert stats.suppressed == 3
+        assert stats.false_positive_rate == pytest.approx(0.5)
+
+    def test_load_respects_since_filter(self, tmp_path):
+        """Old entries outside the window must not skew the digest's
+        'this week' line — we'd rather show nothing than the wrong number."""
+        old = datetime.now(timezone.utc) - timedelta(days=30)
+        new = datetime.now(timezone.utc)
+        record_cycle_noise(
+            GateDecision(confirmed={"old"}), base_path=tmp_path, timestamp=old
+        )
+        record_cycle_noise(
+            GateDecision(confirmed={"new"}, self_resolved={"new2"}),
+            base_path=tmp_path,
+            timestamp=new,
+        )
+        cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+        stats = load_noise_stats(base_path=tmp_path, since=cutoff)
+        # Only the fresh record should be counted.
+        assert stats.alerts_fired == 1
+        assert stats.suppressed == 1
+
+    def test_missing_file_returns_empty_stats(self, tmp_path):
+        stats = load_noise_stats(base_path=tmp_path)
+        assert stats == NoiseStats()
+        assert stats.false_positive_rate is None
+
+    def test_malformed_line_is_skipped(self, tmp_path):
+        path = tmp_path / "noise.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Mix one garbage line with one valid line.
+        path.write_text(
+            "not-json\n"
+            + json.dumps(
+                {
+                    "ts": datetime.now(timezone.utc).isoformat(),
+                    "alerts_fired": 2,
+                    "real_alerts": 2,
+                    "suppressed": 1,
+                }
+            )
+            + "\n"
+        )
+        stats = load_noise_stats(base_path=tmp_path)
+        assert stats.alerts_fired == 2
+        assert stats.suppressed == 1

--- a/tests/test_noise_tracker.py
+++ b/tests/test_noise_tracker.py
@@ -122,6 +122,73 @@ class TestConfirmationGate:
         assert decision.pending == {"c"}
 
 
+class TestStrictBypass:
+    """A strict-marked test must alert on n=1 so safety-critical
+    behaviors can't hide behind the confirmation gate."""
+
+    def test_strict_test_alerts_on_first_failure(self):
+        gate = ConfirmationGate()
+        decision = gate.evaluate(
+            {"payment-flow"}, strict={"payment-flow"}
+        )
+        # Strict bypass: goes straight to alerts_to_fire, no pending.
+        assert decision.strict_immediate == {"payment-flow"}
+        assert decision.alerts_to_fire == {"payment-flow"}
+        assert decision.pending == set()
+        assert decision.confirmed == set()
+
+    def test_strict_test_alerts_every_cycle_until_passing(self):
+        """Unlike confirmed tests (which alert once then stay quiet),
+        strict tests re-alert every cycle they remain broken. The user
+        should never be allowed to forget about an ongoing auth/payment
+        incident."""
+        gate = ConfirmationGate()
+        strict = {"auth"}
+        d1 = gate.evaluate({"auth"}, strict=strict)
+        d2 = gate.evaluate({"auth"}, strict=strict)
+        d3 = gate.evaluate({"auth"}, strict=strict)
+        assert d1.alerts_to_fire == {"auth"}
+        assert d2.alerts_to_fire == {"auth"}
+        assert d3.alerts_to_fire == {"auth"}
+
+    def test_strict_and_relaxed_tests_coexist(self):
+        """Strict bypass must not pollute the relaxed state machine —
+        a strict failure in cycle N should not confuse the gate into
+        thinking a relaxed failure in cycle N was already pending."""
+        gate = ConfirmationGate()
+        # Cycle 1: payment (strict) fails; search (relaxed) fails.
+        d1 = gate.evaluate(
+            {"payment", "search"}, strict={"payment"}
+        )
+        assert d1.strict_immediate == {"payment"}
+        assert d1.pending == {"search"}
+        assert d1.alerts_to_fire == {"payment"}  # only the strict one
+
+        # Cycle 2: both still failing.
+        d2 = gate.evaluate(
+            {"payment", "search"}, strict={"payment"}
+        )
+        # payment: strict → fires again
+        # search: was pending, still failing → promoted to confirmed → fires
+        assert d2.alerts_to_fire == {"payment", "search"}
+        assert d2.confirmed == {"search"}
+        assert d2.strict_immediate == {"payment"}
+
+    def test_strict_flake_still_fires_even_if_self_resolves_next_cycle(self):
+        """A strict test that fails once and recovers STILL fires —
+        that's the whole point. The flake signal is more valuable than
+        the alert suppression for safety-critical paths."""
+        gate = ConfirmationGate()
+        d1 = gate.evaluate({"payment"}, strict={"payment"})
+        d2 = gate.evaluate(set(), strict={"payment"})
+        assert d1.alerts_to_fire == {"payment"}
+        # d2: strict test passed, nothing happens. No suppression
+        # counter either — strict tests never go through the pending
+        # bucket, so there's nothing to "self-resolve".
+        assert d2.alerts_to_fire == set()
+        assert d2.self_resolved == set()
+
+
 # ─────────────────────────── incident detection ───────────────────────────
 
 
@@ -294,3 +361,37 @@ class TestNoisePersistence:
         stats = load_noise_stats(base_path=tmp_path)
         assert stats.alerts_fired == 2
         assert stats.suppressed == 1
+
+    def test_suppressed_test_names_persist_and_aggregate(self, tmp_path):
+        """The per-test suppression list must survive the round-trip so
+        the digest can show WHICH tests were silently suppressed — this
+        is the fix for the 'hidden signal' concern."""
+        # Cycle 1: flaky-search self-resolves.
+        record_cycle_noise(
+            GateDecision(self_resolved={"flaky-search"}),
+            base_path=tmp_path,
+        )
+        # Cycle 2: flaky-search AND auth-retry self-resolve.
+        record_cycle_noise(
+            GateDecision(self_resolved={"flaky-search", "auth-retry"}),
+            base_path=tmp_path,
+        )
+        stats = load_noise_stats(base_path=tmp_path)
+        assert stats.suppressed == 3
+        by_test = {e.test_name: e.count for e in stats.suppressed_by_test}
+        assert by_test == {"flaky-search": 2, "auth-retry": 1}
+        # Most-suppressed first.
+        assert stats.suppressed_by_test[0].test_name == "flaky-search"
+        assert stats.suppressed_by_test[0].count == 2
+
+    def test_strict_alerts_counted_in_alerts_fired(self, tmp_path):
+        """Strict bypass alerts must count toward alerts_fired so the
+        public noise metric stays accurate — otherwise the rate would
+        look artificially low."""
+        record_cycle_noise(
+            GateDecision(strict_immediate={"payment"}),
+            base_path=tmp_path,
+        )
+        stats = load_noise_stats(base_path=tmp_path)
+        assert stats.alerts_fired == 1
+        assert stats.real_alerts == 1

--- a/tests/test_week3_progress_and_drift.py
+++ b/tests/test_week3_progress_and_drift.py
@@ -29,6 +29,7 @@ from evalview.commands.drift_cmd import (
 )
 from evalview.commands.slack_digest_cmd import _build_message, _next_action
 from evalview.core.drift_tracker import DriftTracker
+from evalview.core.noise_tracker import NoiseStats
 
 
 def _entry(**kw: Any) -> Dict[str, Any]:
@@ -352,6 +353,70 @@ def test_build_message_green_headline_on_full_pass() -> None:
     # Inspect the raw payload — json.dumps escapes emoji to \u sequences
     # which would make the assertion lie about what's rendered in Slack.
     assert "🟢" in payload["text"]
+
+
+def test_build_message_omits_noise_section_when_no_activity() -> None:
+    """Empty noise stats should leave the digest tight — no
+    "0% noise" line that would just add clutter on a quiet week."""
+    window = {
+        "total": 10,
+        "pass_rate": 1.0,
+        "regression": 0,
+        "tools_changed": 0,
+        "output_changed": 0,
+    }
+    payload = _build_message(
+        "yesterday", window, [], [], noise_stats=NoiseStats()
+    )
+    text = json.dumps(payload)
+    assert "Noise" not in text
+    assert "suppressed" not in text
+
+
+def test_build_message_renders_noise_section_when_alerts_present() -> None:
+    window = {
+        "total": 10,
+        "pass_rate": 0.9,
+        "regression": 1,
+        "tools_changed": 0,
+        "output_changed": 0,
+    }
+    noise = NoiseStats(alerts_fired=4, real_alerts=4, suppressed=1)
+    payload = _build_message(
+        "yesterday", window, [], [], noise_stats=noise
+    )
+    text = json.dumps(payload)
+    assert "Noise" in text
+    # Publicly reported false-positive rate: 1 / (4+1) = 20%.
+    assert "20%" in text
+    assert "4 fired" in text
+    assert "1 suppressed" in text
+
+
+def test_build_message_noise_section_green_when_clean() -> None:
+    """A low-noise week should lead with the green emoji — the whole
+    point of making this public is to reward being quiet."""
+    window = {
+        "total": 20,
+        "pass_rate": 1.0,
+        "regression": 0,
+        "tools_changed": 0,
+        "output_changed": 0,
+    }
+    noise = NoiseStats(alerts_fired=20, real_alerts=20, suppressed=0)
+    payload = _build_message(
+        "yesterday", window, [], [], noise_stats=noise
+    )
+    # Don't use json.dumps — it escapes emoji.
+    found_noise_block = False
+    for block in payload["blocks"]:
+        if block.get("type") == "section":
+            txt = block.get("text", {}).get("text", "")
+            if "Noise" in txt:
+                found_noise_block = True
+                assert "🟢" in txt
+                assert "0% noise" in txt
+    assert found_noise_block
 
 
 def test_next_action_prioritizes_regression() -> None:

--- a/tests/test_week3_progress_and_drift.py
+++ b/tests/test_week3_progress_and_drift.py
@@ -29,7 +29,7 @@ from evalview.commands.drift_cmd import (
 )
 from evalview.commands.slack_digest_cmd import _build_message, _next_action
 from evalview.core.drift_tracker import DriftTracker
-from evalview.core.noise_tracker import NoiseStats
+from evalview.core.noise_tracker import NoiseStats, SuppressedEntry
 
 
 def _entry(**kw: Any) -> Dict[str, Any]:
@@ -391,6 +391,68 @@ def test_build_message_renders_noise_section_when_alerts_present() -> None:
     assert "20%" in text
     assert "4 fired" in text
     assert "1 suppressed" in text
+
+
+def test_build_message_renders_suppressed_test_list() -> None:
+    """The digest must surface the LIST of suppressed tests, not just
+    a count — otherwise suppression becomes a hidden-signal failure
+    mode. Users need to be able to see "flaky-search self-resolved 3
+    times this week" and decide whether to investigate."""
+    window = {
+        "total": 10,
+        "pass_rate": 0.9,
+        "regression": 0,
+        "tools_changed": 0,
+        "output_changed": 0,
+    }
+    noise = NoiseStats(
+        alerts_fired=2,
+        real_alerts=2,
+        suppressed=4,
+        suppressed_by_test=[
+            SuppressedEntry(test_name="flaky-search", count=3, last_seen=""),
+            SuppressedEntry(test_name="auth-retry", count=1, last_seen=""),
+        ],
+    )
+    payload = _build_message(
+        "yesterday", window, [], [], noise_stats=noise
+    )
+    # Inspect the raw payload — json.dumps escapes unicode (× becomes
+    # \u00d7) which would make the assertion lie about what's rendered.
+    rendered_text = ""
+    for block in payload["blocks"]:
+        if block.get("type") == "section":
+            rendered_text += block.get("text", {}).get("text", "") + "\n"
+    assert "flaky-search" in rendered_text
+    assert "auth-retry" in rendered_text
+    # The count annotation appears for the tests that self-resolved
+    # more than once.
+    assert "× 3" in rendered_text
+    assert "self-resolved" in rendered_text.lower()
+
+
+def test_build_message_suppressed_list_caps_at_five() -> None:
+    """Bounded list so the digest doesn't become its own firehose —
+    show the top 5 + a "…and N more" tail for the long tail."""
+    window = {
+        "total": 10,
+        "pass_rate": 1.0,
+        "regression": 0,
+        "tools_changed": 0,
+        "output_changed": 0,
+    }
+    entries = [
+        SuppressedEntry(test_name=f"t-{i}", count=1, last_seen="")
+        for i in range(8)
+    ]
+    noise = NoiseStats(
+        alerts_fired=1, real_alerts=1, suppressed=8, suppressed_by_test=entries
+    )
+    payload = _build_message(
+        "yesterday", window, [], [], noise_stats=noise
+    )
+    text = json.dumps(payload)
+    assert "and 3 more" in text
 
 
 def test_build_message_noise_section_green_when_clean() -> None:


### PR DESCRIPTION
## Summary

Three noise-reduction moves to make EvalView alerts trustworthy, plus a follow-up fix to ensure suppression never hides a real signal.

### 1. Confirmation gate — never alert on n=1
A failure seen in a single monitor cycle is parked as "pending" and only promoted to a real alert when it re-fails in the next cycle. Flakes that self-resolve within one cycle never page anyone.

### 2. Coordinated incident detection — dedupe by root cause
When ≥3 tests fail together with a shared root cause (declared model change, runtime fingerprint shift, or correlated-batch majority), they collapse into a single Slack incident card. One `likely provider update (high confidence)` ping replaces the 12-alert firehose.

### 3. Public noise metric in the digest
`record_cycle_noise` / `load_noise_stats` persist `alerts_fired` vs `suppressed` counts to `.evalview/noise.jsonl`, and `slack-digest` renders a public `fired · real · suppressed (X% noise)` section — we hold ourselves accountable for our own false-positive rate.

### 4. Strict-gate bypass for safety-critical tests
New YAML field: `gate: strict`. Strict tests bypass the confirmation gate entirely, alert on n=1, and re-alert every cycle they stay broken. Use for auth, payments, PII, refunds — anything where a one-cycle blip is worth investigating immediately.

### 5. Suppression is never silent
The digest now surfaces the **list** of suppressed tests (top-5 with `× count` annotation and a `…and N more` tail), not just a count. One glance tells the user which tests the gate has been swallowing — so `flaky-search × 3` is visible even though no alert fired.

## Emotional contract

- Low-stakes test fails once and recovers → no alert, visible in digest as suppressed.
- Low-stakes test fails twice in a row → confirmed alert.
- Safety-critical (`gate: strict`) test fails once → immediate alert, re-alerts every cycle until fixed.
- Every suppression is recorded and visible. Suppressing the alert is fine; suppressing the signal is not.

## Files changed

**New**
- `evalview/core/noise_tracker.py` — `ConfirmationGate`, `detect_coordinated_incident`, `NoiseStats`, `SuppressedEntry`, `record_cycle_noise`, `load_noise_stats`
- `tests/test_noise_tracker.py` — 32 tests pinning the gate state machine, strict bypass, incident rules, persistence round-trip, and since-filter

**Modified**
- `evalview/commands/monitor_cmd.py` — both CLI and dashboard loops route failures through the gate, extract strict tests from YAML, record noise stats per cycle
- `evalview/core/slack_notifier.py` + `evalview/core/discord_notifier.py` — `send_regression_alert` accepts optional `incident` kwarg and renders a collapsed incident card when present
- `evalview/commands/slack_digest_cmd.py` — Noise section with false-positive rate + suppressed-tests list
- `evalview/core/types.py` — new `gate: Optional[str]` field on `TestCase`
- `tests/test_monitor.py` — incident-collapse Slack path
- `tests/test_week3_progress_and_drift.py` — noise section rendering, suppressed list rendering, top-5 cap

## Test plan

- [x] 32 new `test_noise_tracker.py` tests pass
- [x] Incident-collapse Slack path test passes
- [x] Digest noise-section tests pass (green on clean weeks, shows list on suppression weeks)
- [x] 321 tests pass across all impacted areas (`noise_tracker`, `monitor`, `week3`, `types`, `loader`, `config`, `check_cmd`)
- [x] Zero regressions in existing test suite (the one unrelated failure in `test_snapshot_generated_workflow` is pre-existing on the branch)
- [ ] Manual smoke test: run `evalview monitor` on a flaky test to verify the pending-confirmation console output
- [ ] Manual smoke test: run `evalview slack-digest --dry-run` after seeding some `noise.jsonl` entries to verify the rendered Noise section

https://claude.ai/code/session_01Pj3qevTSnyAWHEztiws44J