### PR TITLE
docs(cli): add evalview monitor reference + wire monitor into dogfood CI

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -130,6 +130,69 @@ jobs:
         kill $MOCK_PID 2>/dev/null || true
         wait $MOCK_PID 2>/dev/null || true
 
+    - name: Monitor smoke test (populate .evalview/noise.jsonl)
+      id: monitor
+      continue-on-error: true
+      run: |
+        # Exercises the full `evalview monitor` loop — confirmation gate,
+        # coordinated-incident detection, and the noise tracker — so
+        # `.evalview/noise.jsonl` gets real data instead of staying empty.
+        # Wiring monitor into dogfood is the prerequisite for unlocking
+        # the deferred repeat-suppression / auto-quarantine features.
+        #
+        # Reuses the deterministic mock agent and the golden baselines
+        # produced by the regression step above.
+
+        uv run python dogfood/mock_agent.py &
+        MOCK_PID=$!
+
+        AGENT_READY=false
+        for i in $(seq 1 15); do
+          if curl -sf http://localhost:8002/health > /dev/null; then
+            echo "Mock agent ready after ${i}s"
+            AGENT_READY=true
+            break
+          fi
+          sleep 1
+        done
+
+        if [ "$AGENT_READY" = "false" ]; then
+          echo "Mock agent failed to start within 15s" >&2
+          echo "exit_code=1" >> $GITHUB_OUTPUT
+          kill $MOCK_PID 2>/dev/null || true
+          exit 0
+        fi
+
+        # Run the monitor for ~35s. Minimum --interval is 10s, so that
+        # gives us ~3 cycles — enough to exercise both the initial cycle
+        # and the confirmation gate state transitions. --preserve-status
+        # makes timeout return monitor's own exit code (0 for a clean
+        # shutdown) rather than 124.
+        timeout --preserve-status 35s \
+          uv run evalview monitor dogfood/mock-agent-tests/ \
+            --interval 10 \
+            --timeout 15 \
+            --fail-on REGRESSION \
+            --history .evalview/monitor-history.jsonl \
+            2>&1 | tee monitor-output.txt || true
+        MONITOR_EXIT=${PIPESTATUS[0]}
+        echo "monitor exit code: $MONITOR_EXIT"
+
+        # Verify the noise log was populated. An empty file means the
+        # monitor loop never completed a cycle, which is a regression in
+        # the feature we are dogfooding.
+        if [ ! -s .evalview/noise.jsonl ]; then
+          echo "FAIL: .evalview/noise.jsonl was not written — monitor smoke test did not exercise the noise tracker" >&2
+          echo "exit_code=1" >> $GITHUB_OUTPUT
+        else
+          echo "Noise log contents:"
+          cat .evalview/noise.jsonl
+          echo "exit_code=$MONITOR_EXIT" >> $GITHUB_OUTPUT
+        fi
+
+        kill $MOCK_PID 2>/dev/null || true
+        wait $MOCK_PID 2>/dev/null || true
+
     - name: Run dogfood self-tests (chat mode)
       id: dogfood
       continue-on-error: true
@@ -219,6 +282,10 @@ jobs:
 
         if [ "${{ steps.regression.outputs.exit_code }}" != "0" ]; then
           FAILED="${FAILED}regression,"
+        fi
+
+        if [ "${{ steps.monitor.outputs.exit_code }}" != "0" ]; then
+          FAILED="${FAILED}monitor,"
         fi
 
         if [ "${{ steps.dogfood.outputs.exit_code }}" != "0" ] && [ "${{ steps.dogfood.outputs.skipped }}" != "true" ]; then
@@ -340,6 +407,12 @@ jobs:
           echo "✅ regression check passed (EvalView evaluating itself)" >> $GITHUB_STEP_SUMMARY
         else
           echo "❌ regression check failed — EvalView evaluation logic may have regressed" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        if [ "${{ steps.monitor.outputs.exit_code }}" == "0" ]; then
+          echo "✅ monitor smoke test passed (.evalview/noise.jsonl populated)" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "❌ monitor smoke test failed — noise tracker may not be recording cycles" >> $GITHUB_STEP_SUMMARY
         fi
 
         if [ "${{ steps.dogfood.outputs.skipped }}" == "true" ]; then

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -163,6 +163,85 @@ evalview check --budget 0.50               # Cap spend at $0.50
 
 The terminal output and HTML report surface the classification (`declared` or `suspected`), confidence, runtime fingerprint diff, and retry evidence from `evalview check --heal` when available.
 
+---
+
+## `evalview monitor`
+
+Continuously run checks against a live agent and alert on regressions. Designed for production monitoring: `evalview monitor` runs `evalview check` in a loop, fires Slack/Discord alerts only for failures confirmed across two consecutive cycles, and records the full signal-to-noise trail in `.evalview/noise.jsonl` so `evalview slack-digest` can report a verifiable false-positive rate.
+
+```bash
+evalview monitor [TEST_PATH] [OPTIONS]
+
+Options:
+  -i, --interval N         Seconds between checks (default: 300, minimum: 10)
+  --slack-webhook URL      Slack webhook URL for alerts
+  --discord-webhook URL    Discord webhook URL for alerts
+  --fail-on STATUSES       Comma-separated statuses that trigger alerts
+                           (default: REGRESSION)
+  --timeout FLOAT          Timeout per test in seconds (default: 30)
+  -t, --test TEXT          Monitor only this specific test
+  --history PATH           Append each cycle's results to a JSONL file
+  --alert-cost-spike X     Alert when cost exceeds baseline by this
+                           multiplier (e.g. 2.0)
+  --alert-latency-spike X  Alert when latency exceeds baseline by this
+                           multiplier (e.g. 3.0)
+  --dashboard              Live-updating terminal dashboard instead of
+                           scrolling logs
+```
+
+### Confirmation gate
+
+Every alert is a promise. By default the monitor suppresses `n=1` failures: a test has to fail in two consecutive cycles before it pages a human, and a single blip self-resolves silently. Tests that must alert on the first failure (auth, payments, PII, refund paths) can opt out of the gate by setting `gate: strict` in their YAML; strict tests bypass confirmation and re-alert every cycle until they pass.
+
+Self-resolved (suppressed) failures are never dropped: they are appended to `.evalview/noise.jsonl` with their test names, so `evalview slack-digest` can render a Noise section with an exact `N suppressed / M fired = Z% noise` false-positive rate.
+
+### Prerequisites
+
+`evalview monitor` requires existing baselines. Run `evalview snapshot` first to create them, otherwise the monitor exits immediately with the error `No baselines found. Run evalview snapshot first.`
+
+### Configuration (`.evalview/config.yaml`)
+
+```yaml
+monitor:
+  interval: 300
+  slack_webhook: https://hooks.slack.com/services/...
+  discord_webhook: https://discord.com/api/webhooks/...
+  fail_on: [REGRESSION]
+  cost_threshold: 2.0
+  latency_threshold: 3.0
+```
+
+Webhook URLs can also be provided via environment variables as a fallback:
+
+| Variable | Description |
+|----------|-------------|
+| `EVALVIEW_SLACK_WEBHOOK` | Slack webhook URL (fallback) |
+| `EVALVIEW_DISCORD_WEBHOOK` | Discord webhook URL (fallback) |
+
+### Examples
+
+```bash
+evalview monitor                                 # Check every 5 min
+evalview monitor --interval 60                   # Check every minute
+evalview monitor --dashboard                     # Live terminal dashboard
+evalview monitor --slack-webhook https://...     # Alert to Slack
+evalview monitor --discord-webhook https://...   # Alert to Discord
+evalview monitor --test "weather-lookup"         # Monitor one test
+evalview monitor --fail-on REGRESSION,TOOLS_CHANGED
+evalview monitor --history monitor_log.jsonl     # Persist cycle history
+evalview monitor --alert-cost-spike 2.0          # Alert if cost doubles
+evalview monitor --alert-latency-spike 3.0       # Alert if latency triples
+```
+
+### Related files
+
+| Path | Written by | Purpose |
+|------|-----------|---------|
+| `.evalview/noise.jsonl` | monitor loop | One line per cycle with `alerts_fired`, `suppressed`, and the names of self-resolved tests. Consumed by `evalview slack-digest` to report a false-positive rate. |
+| `<--history PATH>` | `--history` | Optional per-cycle diagnostic log (total tests, pass/fail counts, cost, failing test names). Separate from the noise log. |
+
+---
+
 ## `evalview model-check`
 
 Detect silent drift in a closed-weight model (Claude, GPT, ...) against
@@ -476,3 +555,4 @@ Note: non-OpenAI aliases (`DEEPSEEK_API_KEY`, `KIMI_API_KEY`, `MOONSHOT_API_KEY`
 - [Golden Traces](GOLDEN_TRACES.md)
 - [Statistical Mode](STATISTICAL_MODE.md)
 - [Chat Mode](CHAT_MODE.md)
+- [Monitor Config Options](#evalview-monitor)


### PR DESCRIPTION
## Summary

Addresses both follow-ups:

- **`docs/CLI_REFERENCE.md` had no `evalview monitor` section** even though the README linked to it for monitor config options. Adds a full reference section (between `check` and `model-check`) covering all 10 CLI options, the confirmation gate / `gate: strict` bypass, `.evalview/config.yaml` keys, env var fallbacks, prerequisites, examples, and a Related files table distinguishing `.evalview/noise.jsonl` from the optional `--history` log.
- **`evalview monitor` was not invoked in CI** so `.evalview/noise.jsonl` never had real data. Adds a "Monitor smoke test" step to `dogfood.yml` that reuses the mock agent + golden baselines from the existing regression step and runs `timeout --preserve-status 35s uv run evalview monitor dogfood/mock-agent-tests/ --interval 10 ...`, giving ~3 cycles through the confirmation gate. The step fails if `.evalview/noise.jsonl` is not written, so a silent regression in the noise tracker is caught. This unblocks the deferred repeat-suppression / auto-quarantine features.

The new step is hooked into the existing "Check for failures" aggregation and `$GITHUB_STEP_SUMMARY` block.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the updated workflow
- [x] `evalview monitor --help` verified against the documented option list
- [x] End-to-end smoke test locally: started `dogfood/mock_agent.py`, ran `evalview snapshot --path dogfood/mock-agent-tests/ --no-judge`, then executed the exact `timeout --preserve-status 35s uv run evalview monitor ...` command from the new workflow step. Monitor completed 4 cycles and wrote 4 records to `.evalview/noise.jsonl` (`alerts_fired`, `suppressed`, per-test names).
- [ ] Confirm the next scheduled / `workflow_dispatch` run of `Daily Dogfood` reports `monitor smoke test passed (.evalview/noise.jsonl populated)` in the step summary

https://claude.ai/code/session_01KHpgDmMjZDHvjPDmQNCZEd