### PR TITLE
fix(mypy): resolve 7 Type Check CI failures in slack_digest + progress

### DIFF
--- a/evalview/commands/progress_cmd.py
+++ b/evalview/commands/progress_cmd.py
@@ -165,6 +165,9 @@ def _compute_delta(
         if a is None and b is not None:
             # Dropped test — don't count as either improvement or regression
             continue
+        # Both early-continues above guarantee both `a` and `b` are non-None
+        # by this point. Explicit assertion narrows mypy's Optional types.
+        assert a is not None and b is not None
         if not is_pass(b) and is_pass(a):
             improved.append((name, str(a.get("git_sha") or "") or None))
         elif is_pass(b) and not is_pass(a):

--- a/evalview/commands/slack_digest_cmd.py
+++ b/evalview/commands/slack_digest_cmd.py
@@ -191,11 +191,11 @@ def _build_message(
     if stale_quarantine:
         n = len(stale_quarantine)
         preview_lines = []
-        for entry in stale_quarantine[:3]:
-            owner = entry.get("owner") or "<unknown>"
-            age = entry.get("age_days")
+        for stale in stale_quarantine[:3]:
+            owner = stale.get("owner") or "<unknown>"
+            age = stale.get("age_days")
             age_str = f"{age}d" if age is not None else "?"
-            preview_lines.append(f"• {entry.get('test_name')} — {owner} — {age_str}")
+            preview_lines.append(f"• {stale.get('test_name')} — {owner} — {age_str}")
         blocks.append(
             {
                 "type": "section",
@@ -355,6 +355,9 @@ def slack_digest_cmd(
         console.print(json.dumps(payload, indent=2))
         return
 
+    # The early `not webhook and not dry_run` guard above guarantees
+    # a non-None webhook by the time we reach this branch.
+    assert webhook is not None
     ok = _post_to_slack(webhook, payload)
     if ok:
         console.print("[green]✓ Digest posted to Slack.[/green]")


### PR DESCRIPTION
Every PR since #166 has shipped to main with the `Type Check` CI job failing — no one was blocking merges on it, but the badge has been red on every run. All 7 errors live in two commands that were added in the Week 2-3 investigative-loop work:

slack_digest_cmd.py
  - Reused the loop variable `entry` for both `noise_stats.suppressed_by_test` (typed as SuppressedEntry) and `stale_quarantine[:3]` (typed as dict[str, Any]). mypy locked `entry` to SuppressedEntry from the first loop, so the dict-style .get() calls on the second loop all errored. Renamed the quarantine loop variable to `stale` to keep the two types separate.
  - _post_to_slack expects str, but `webhook: Optional[str]` was passed through directly. The early `not webhook and not dry_run` guard already ensures webhook is non-None by the post-to-slack branch; added an explicit `assert webhook is not None` to narrow the type for mypy.

progress_cmd.py
  - In the improved/regressed classification loop, `a` is typed Optional[dict] but is dereferenced via `a.get("git_sha")`. The early `a is None and b is not None: continue` guard already eliminates the None case, but mypy can't narrow across the `is_pass(...)` helper. Added an explicit `assert a is not None and b is not None` after both early-continues — documents the invariant and fixes the union-attr errors on both branches.

No behavior change. Verified:
  - `uv run mypy evalview/` → "Success: no issues found in 199 source files"
  - tests/test_week3_progress_and_drift.py + tests/test_noise_tracker.py → 70 passed (the suites that cover the touched code paths)

https://claude.ai/code/session_017sc1uHapk5aRJjpCK81eJ7

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #(issue number)

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Changes Made

<!-- Provide a detailed list of changes -->

-
-
-

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

### Test Configuration

- **Python Version**:
- **OS**:

### Tests Added/Modified

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests pass locally
- [ ] Test coverage maintained or improved

### Manual Testing Steps

1.
2.
3.

## Checklist

<!-- Check all that apply -->

### Code Quality

- [ ] My code follows the project's style guidelines
- [ ] I have run `black` to format my code
- [ ] I have run `ruff` and fixed any linting issues
- [ ] I have run `mypy` and fixed any type errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

### Documentation

- [ ] I have updated the documentation (README, CONTRIBUTING, etc.)
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated the CHANGELOG.md (if applicable)

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this with multiple agent frameworks (if applicable)

### Dependencies

- [ ] I have checked that no new dependencies were added unnecessarily
- [ ] If dependencies were added, I have updated `pyproject.toml`
- [ ] I have verified that the new dependencies are compatible with Python 3.9+

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

## Reviewer Notes

<!-- Notes for reviewers about areas that need special attention -->

---

**By submitting this pull request, I confirm that:**

- [ ] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] I agree to the project's [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [ ] My contribution is my own work and I have the right to contribute it
