### PR TITLE
Slow agent warning

### DIFF
--- a/evalview/commands/shared.py
+++ b/evalview/commands/shared.py
@@ -613,6 +613,13 @@ def _execute_check_tests(
     diffs: List[Tuple[str, "TraceDiff"]] = []
     golden_traces: Dict[str, GoldenTrace] = {}
 
+    async def _slow_agent_warning_task(test_name: str) -> None:
+        await asyncio.sleep(max(0.0, timeout * 0.5))
+        console.print(
+            f"[yellow]⚠ {test_name}: Agent is taking a while... "
+            f"({timeout * 0.5:.1f}s elapsed, {timeout:.1f}s timeout)[/yellow]"
+        )
+
     if budget_tracker is not None:
         # Sequential execution with budget checking after each test
         async def _run_one_sequential(tc: "TestCase") -> Optional[Tuple["EvaluationResult", "TraceDiff", "GoldenTrace"]]:
@@ -626,10 +633,21 @@ def _execute_check_tests(
             if adapter is None:
                 return None
 
-            if tc.is_multi_turn:
-                trace = await _execute_multi_turn_trace(tc, adapter)
-            else:
-                trace = await adapter.execute(tc.input.query, tc.input.context)
+            warning_task: Optional[asyncio.Task] = None
+            if not json_output:
+                warning_task = asyncio.create_task(_slow_agent_warning_task(tc.name))
+            try:
+                if tc.is_multi_turn:
+                    trace = await _execute_multi_turn_trace(tc, adapter)
+                else:
+                    trace = await adapter.execute(tc.input.query, tc.input.context)
+            finally:
+                if warning_task is not None:
+                    warning_task.cancel()
+                    try:
+                        await warning_task
+                    except asyncio.CancelledError:
+                        pass
             result = await evaluator.evaluate(tc, trace)
 
             golden_variants = store.load_all_golden_variants(tc.name)
@@ -693,10 +711,21 @@ def _execute_check_tests(
             if adapter is None:
                 return None
 
-            if tc.is_multi_turn:
-                trace = await _execute_multi_turn_trace(tc, adapter)
-            else:
-                trace = await adapter.execute(tc.input.query, tc.input.context)
+            warning_task: Optional[asyncio.Task] = None
+            if not json_output:
+                warning_task = asyncio.create_task(_slow_agent_warning_task(tc.name))
+            try:
+                if tc.is_multi_turn:
+                    trace = await _execute_multi_turn_trace(tc, adapter)
+                else:
+                    trace = await adapter.execute(tc.input.query, tc.input.context)
+            finally:
+                if warning_task is not None:
+                    warning_task.cancel()
+                    try:
+                        await warning_task
+                    except asyncio.CancelledError:
+                        pass
             result = await evaluator.evaluate(tc, trace)
 
             golden_variants = store.load_all_golden_variants(tc.name)

--- a/evalview/commands/shared.py
+++ b/evalview/commands/shared.py
@@ -614,6 +614,14 @@ def _execute_check_tests(
     golden_traces: Dict[str, GoldenTrace] = {}
 
     async def _slow_agent_warning_task(test_name: str) -> None:
+        """Background task that shows slow-agent warning after 50% of timeout.
+        
+        Args:
+            test_name: Name of the test being executed.
+            
+        Waits for 50% of timeout duration, then prints a warning
+        message indicating that agent is taking longer than expected.
+        """
         await asyncio.sleep(max(0.0, timeout * 0.5))
         console.print(
             f"[yellow]⚠ {test_name}: Agent is taking a while... "

--- a/tests/test_check_pipeline.py
+++ b/tests/test_check_pipeline.py
@@ -274,6 +274,7 @@ class TestSlowAgentWarning:
         assert "0.2s timeout" in printed
 
     def test_warning_printed_only_once(self, project, monkeypatch):
+        """Test that warning prints only once per test execution."""
         from evalview.commands.shared import _execute_check_tests
         from evalview.core.config import EvalViewConfig
 

--- a/tests/test_check_pipeline.py
+++ b/tests/test_check_pipeline.py
@@ -225,6 +225,178 @@ class TestConcurrentExecution:
         assert "test-b" in diff_names, "test-b should still complete even though test-a failed"
 
 
+class TestSlowAgentWarning:
+    @pytest.fixture
+    def project(self, tmp_path):
+        _write_config(tmp_path)
+        _write_test_yaml(tmp_path / "tests", "my-test")
+        _write_golden(tmp_path, "my-test")
+        return tmp_path
+
+    def test_warning_emitted_after_half_timeout(self, project, monkeypatch):
+        from evalview.commands.shared import _execute_check_tests
+        from evalview.core.config import EvalViewConfig
+
+        monkeypatch.chdir(project)
+
+        fake_trace = _make_fake_trace()
+        fake_result = _make_fake_result("my-test")
+        fake_result.trace = fake_trace
+
+        async def _slow_execute(query, context):
+            import asyncio
+            await asyncio.sleep(0.25)
+            return fake_trace
+
+        mock_adapter = MagicMock()
+        mock_adapter.execute = _slow_execute
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate = AsyncMock(return_value=fake_result)
+
+        from evalview.core.loader import TestCaseLoader
+        loader = TestCaseLoader()
+        test_cases = loader.load_from_directory(str(project / "tests"))
+
+        config = EvalViewConfig(adapter="http", endpoint="http://example.com")
+
+        mock_console = MagicMock()
+
+        with (
+            patch("evalview.commands.shared._create_adapter", return_value=mock_adapter),
+            patch("evalview.evaluators.evaluator.Evaluator", return_value=mock_evaluator),
+            patch("evalview.commands.shared.console", mock_console),
+        ):
+            _execute_check_tests(test_cases, config, json_output=False, timeout=0.2)
+
+        printed = "\n".join(str(c.args[0]) for c in mock_console.print.call_args_list if c.args)
+        assert "Agent is taking a while" in printed
+        assert "0.1s elapsed" in printed
+        assert "0.2s timeout" in printed
+
+    def test_warning_printed_only_once(self, project, monkeypatch):
+        from evalview.commands.shared import _execute_check_tests
+        from evalview.core.config import EvalViewConfig
+
+        monkeypatch.chdir(project)
+
+        fake_trace = _make_fake_trace()
+        fake_result = _make_fake_result("my-test")
+        fake_result.trace = fake_trace
+
+        async def _slow_execute(query, context):
+            import asyncio
+            await asyncio.sleep(0.25)
+            return fake_trace
+
+        mock_adapter = MagicMock()
+        mock_adapter.execute = _slow_execute
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate = AsyncMock(return_value=fake_result)
+
+        from evalview.core.loader import TestCaseLoader
+        loader = TestCaseLoader()
+        test_cases = loader.load_from_directory(str(project / "tests"))
+
+        config = EvalViewConfig(adapter="http", endpoint="http://example.com")
+
+        mock_console = MagicMock()
+
+        with (
+            patch("evalview.commands.shared._create_adapter", return_value=mock_adapter),
+            patch("evalview.evaluators.evaluator.Evaluator", return_value=mock_evaluator),
+            patch("evalview.commands.shared.console", mock_console),
+        ):
+            _execute_check_tests(test_cases, config, json_output=False, timeout=0.2)
+
+        warning_calls = [
+            c for c in mock_console.print.call_args_list
+            if c.args and "Agent is taking a while" in str(c.args[0])
+        ]
+        assert len(warning_calls) == 1
+
+    def test_warning_suppressed_in_json_output_mode(self, project, monkeypatch):
+        from evalview.commands.shared import _execute_check_tests
+        from evalview.core.config import EvalViewConfig
+
+        monkeypatch.chdir(project)
+
+        fake_trace = _make_fake_trace()
+        fake_result = _make_fake_result("my-test")
+        fake_result.trace = fake_trace
+
+        async def _slow_execute(query, context):
+            import asyncio
+            await asyncio.sleep(0.25)
+            return fake_trace
+
+        mock_adapter = MagicMock()
+        mock_adapter.execute = _slow_execute
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate = AsyncMock(return_value=fake_result)
+
+        from evalview.core.loader import TestCaseLoader
+        loader = TestCaseLoader()
+        test_cases = loader.load_from_directory(str(project / "tests"))
+
+        config = EvalViewConfig(adapter="http", endpoint="http://example.com")
+
+        mock_console = MagicMock()
+
+        with (
+            patch("evalview.commands.shared._create_adapter", return_value=mock_adapter),
+            patch("evalview.evaluators.evaluator.Evaluator", return_value=mock_evaluator),
+            patch("evalview.commands.shared.console", mock_console),
+        ):
+            _execute_check_tests(test_cases, config, json_output=True, timeout=0.2)
+
+        warning_calls = [
+            c for c in mock_console.print.call_args_list
+            if c.args and "Agent is taking a while" in str(c.args[0])
+        ]
+        assert len(warning_calls) == 0
+
+    def test_no_warning_when_execution_completes_quickly(self, project, monkeypatch):
+        from evalview.commands.shared import _execute_check_tests
+        from evalview.core.config import EvalViewConfig
+
+        monkeypatch.chdir(project)
+
+        fake_trace = _make_fake_trace()
+        fake_result = _make_fake_result("my-test")
+        fake_result.trace = fake_trace
+
+        async def _fast_execute(query, context):
+            import asyncio
+            await asyncio.sleep(0.05)
+            return fake_trace
+
+        mock_adapter = MagicMock()
+        mock_adapter.execute = _fast_execute
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate = AsyncMock(return_value=fake_result)
+
+        from evalview.core.loader import TestCaseLoader
+        loader = TestCaseLoader()
+        test_cases = loader.load_from_directory(str(project / "tests"))
+
+        config = EvalViewConfig(adapter="http", endpoint="http://example.com")
+
+        mock_console = MagicMock()
+
+        with (
+            patch("evalview.commands.shared._create_adapter", return_value=mock_adapter),
+            patch("evalview.evaluators.evaluator.Evaluator", return_value=mock_evaluator),
+            patch("evalview.commands.shared.console", mock_console),
+        ):
+            _execute_check_tests(test_cases, config, json_output=False, timeout=0.2)
+
+        warning_calls = [
+            c for c in mock_console.print.call_args_list
+            if c.args and "Agent is taking a while" in str(c.args[0])
+        ]
+        assert len(warning_calls) == 0
+
+
 # ---------------------------------------------------------------------------
 # Test: DriftTracker is reused in _display_check_results (no dual instantiation)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This PR adds a slow-agent warning (e.g. "Agent is taking a while...") when an agent call exceeds 50% of the configured timeout but hasn't timed out yet.

## Related Issue

Fixes https://github.com/hidai25/eval-view/issues/142

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Changes Made

- Added slow-agent warning logic in check execution pipeline (evalview/commands/shared.py, _execute_check_tests) using a background async task that triggers at timeout * 0.5.
- Ensured warning prints only once per test execution and is always cleaned up by cancelling the background task when the test finishes (success, failure, or exception).
- Ensured warning never prints in JSON mode by guarding the warning task behind if not json_output.
- Added tests in tests/test_check_pipeline.py covering all acceptance criteria.

## Testing

### Test Configuration

- **Python Version**: 3.13.7
- **OS**: Windows

### Tests Added/Modified

- [X] Unit tests added/updated
- [X] All tests pass locally
- [X] Test coverage maintained or improved

### Manual Testing Steps

1. Ran pytest tests/test_check_pipeline.py::TestSlowAgentWarning -v
2. Ran pytest tests/test_check_pipeline.py -v

## Checklist

### Code Quality

- [x] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code


### Documentation

- [X] I have added docstrings to new functions/classes

### Testing

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

### Dependencies

- [X] I have checked that no new dependencies were added unnecessarily


## Screenshots
<img width="1382" height="945" alt="evalview3" src="https://github.com/user-attachments/assets/d5b09539-f3d4-4e51-ac32-7e0e65e99c18" />


## Additional Notes

I have implemented this feature in the check execution pipeline, and not inside the HTTP adapter, because the issue mentions "agent call," but the scope and acceptance criteria are explicitly CLI/test-run UX focused:

- "Show it once per test execution": Implementing inside an adapter risks multiple warnings if an agent makes multiple internal calls; the check execution pipeline can reliably scope it to a single test execution.
- "Only in non-JSON output mode": Adapters are low-level and shouldn't need awareness of CLI output mode; the check execution logic already has json_output context.
- "Applies across adapters": The check pipeline can run with multiple adapter types; implementing at the check execution logic level makes the behavior consistent.

So this PR follows the intent while matching all acceptance criteria.


## Reviewer Notes

Please verify the decision to implement the feature in the check execution logic rather than the HTTP adapter to ensure consistency across all adapter types and proper JSON output handling.

---

**By submitting this pull request, I confirm that:**

- [X] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [X] I agree to the project's [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [X] My contribution is my own work and I have the right to contribute it