### PR TITLE
fix(monitor): satisfy mypy on incidents_path narrowing

### DIFF
--- a/evalview/commands/monitor_cmd.py
+++ b/evalview/commands/monitor_cmd.py
@@ -867,8 +867,10 @@ def monitor(
         resolved_incidents: Optional[Path] = None
     elif incidents_path_opt:
         resolved_incidents = Path(incidents_path_opt)
-    elif monitor_cfg is not None and getattr(monitor_cfg, "incidents_path", None):
-        resolved_incidents = Path(monitor_cfg.incidents_path)
+    elif monitor_cfg is not None and (
+        cfg_incidents_path := getattr(monitor_cfg, "incidents_path", None)
+    ):
+        resolved_incidents = Path(cfg_incidents_path)
     elif monitor_cfg is not None and getattr(monitor_cfg, "incidents_enabled", False):
         resolved_incidents = DEFAULT_INCIDENTS_PATH
     else:


### PR DESCRIPTION
## Summary

The `Type Check` CI job started failing on `main` after #172 introduced the incidents-logging block in `evalview/commands/monitor_cmd.py`. mypy couldn't narrow `monitor_cfg.incidents_path` from `Optional[str]` to `str` across two separate accesses (a `getattr` truthiness check followed by a direct attribute read), so the follow-up `Path(monitor_cfg.incidents_path)` tripped `arg-type`.

Fix: bind the value via a walrus on the guard so mypy sees a single narrowed local. No runtime behavior change.

## Test plan

- [x] `uv run mypy evalview/` → `Success: no issues found in 202 source files`
- [x] `pytest -k "monitor and incident"` → 4 passed (covers `tests/test_autopr.py` + `tests/test_monitor.py`)

https://claude.ai/code/session_01JaxCAKsR2qMigwnfVJqcZb