### PR TITLE
fix(slow-agent-warning): real elapsed + snapshot path + DRY

### DIFF
--- a/evalview/commands/shared.py
+++ b/evalview/commands/shared.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import time
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
@@ -506,6 +507,46 @@ def _build_adapter_for_tc(
     return _create_adapter(adapter_type, endpoint or "", timeout=timeout, allow_private_urls=allow_private)
 
 
+async def _execute_agent_with_slow_warning(
+    tc: "TestCase",
+    adapter: "AgentAdapter",
+    timeout: float,
+    emit_warning: bool = True,
+) -> ExecutionTrace:
+    """Execute the agent for `tc`, printing a slow-agent warning at 50% of timeout.
+
+    Prints the real measured elapsed time (not `timeout * 0.5`), so the message
+    stays accurate if event-loop scheduling slips. The background warning task is
+    always cancelled in the finally block.
+    """
+    warning_task: Optional[asyncio.Task] = None
+    if emit_warning and timeout > 0:
+        start = time.monotonic()
+        warn_after = timeout * 0.5
+
+        async def _warn() -> None:
+            await asyncio.sleep(warn_after)
+            elapsed = time.monotonic() - start
+            console.print(
+                f"[yellow]⚠ {tc.name}: Agent is taking a while... "
+                f"({elapsed:.1f}s elapsed of {timeout:.1f}s timeout)[/yellow]"
+            )
+
+        warning_task = asyncio.create_task(_warn())
+
+    try:
+        if tc.is_multi_turn:
+            return await _execute_multi_turn_trace(tc, adapter)
+        return await adapter.execute(tc.input.query, tc.input.context)
+    finally:
+        if warning_task is not None:
+            warning_task.cancel()
+            try:
+                await warning_task
+            except asyncio.CancelledError:
+                pass
+
+
 def _execute_snapshot_tests(
     test_cases: List["TestCase"],
     config: Optional["EvalViewConfig"],
@@ -528,10 +569,7 @@ def _execute_snapshot_tests(
             console.print(f"[yellow]⚠ Skipping {tc.name}: No adapter/endpoint configured[/yellow]")
             return None
 
-        if tc.is_multi_turn:
-            trace = await _execute_multi_turn_trace(tc, adapter)
-        else:
-            trace = await adapter.execute(tc.input.query, tc.input.context)
+        trace = await _execute_agent_with_slow_warning(tc, adapter, timeout)
         return await evaluator.evaluate(tc, trace)
 
     async def _run_all() -> List[Any]:
@@ -625,21 +663,6 @@ def _execute_check_tests(
     diffs: List[Tuple[str, "TraceDiff"]] = []
     golden_traces: Dict[str, GoldenTrace] = {}
 
-    async def _slow_agent_warning_task(test_name: str) -> None:
-        """Background task that shows slow-agent warning after 50% of timeout.
-        
-        Args:
-            test_name: Name of the test being executed.
-            
-        Waits for 50% of timeout duration, then prints a warning
-        message indicating that agent is taking longer than expected.
-        """
-        await asyncio.sleep(max(0.0, timeout * 0.5))
-        console.print(
-            f"[yellow]⚠ {test_name}: Agent is taking a while... "
-            f"({timeout * 0.5:.1f}s elapsed, {timeout:.1f}s timeout)[/yellow]"
-        )
-
     if budget_tracker is not None:
         # Sequential execution with budget checking after each test
         async def _run_one_sequential(tc: "TestCase") -> Optional[Tuple["EvaluationResult", "TraceDiff", "GoldenTrace"]]:
@@ -653,21 +676,9 @@ def _execute_check_tests(
             if adapter is None:
                 return None
 
-            warning_task: Optional[asyncio.Task] = None
-            if not json_output:
-                warning_task = asyncio.create_task(_slow_agent_warning_task(tc.name))
-            try:
-                if tc.is_multi_turn:
-                    trace = await _execute_multi_turn_trace(tc, adapter)
-                else:
-                    trace = await adapter.execute(tc.input.query, tc.input.context)
-            finally:
-                if warning_task is not None:
-                    warning_task.cancel()
-                    try:
-                        await warning_task
-                    except asyncio.CancelledError:
-                        pass
+            trace = await _execute_agent_with_slow_warning(
+                tc, adapter, timeout, emit_warning=not json_output
+            )
             result = await evaluator.evaluate(tc, trace)
 
             golden_variants = store.load_all_golden_variants(tc.name)
@@ -731,21 +742,9 @@ def _execute_check_tests(
             if adapter is None:
                 return None
 
-            warning_task: Optional[asyncio.Task] = None
-            if not json_output:
-                warning_task = asyncio.create_task(_slow_agent_warning_task(tc.name))
-            try:
-                if tc.is_multi_turn:
-                    trace = await _execute_multi_turn_trace(tc, adapter)
-                else:
-                    trace = await adapter.execute(tc.input.query, tc.input.context)
-            finally:
-                if warning_task is not None:
-                    warning_task.cancel()
-                    try:
-                        await warning_task
-                    except asyncio.CancelledError:
-                        pass
+            trace = await _execute_agent_with_slow_warning(
+                tc, adapter, timeout, emit_warning=not json_output
+            )
             result = await evaluator.evaluate(tc, trace)
 
             golden_variants = store.load_all_golden_variants(tc.name)

--- a/tests/test_check_pipeline.py
+++ b/tests/test_check_pipeline.py
@@ -226,6 +226,8 @@ class TestConcurrentExecution:
 
 
 class TestSlowAgentWarning:
+    """Slow-agent warning fires once at 50% of timeout, respects --json mode."""
+
     @pytest.fixture
     def project(self, tmp_path):
         _write_config(tmp_path)
@@ -233,32 +235,27 @@ class TestSlowAgentWarning:
         _write_golden(tmp_path, "my-test")
         return tmp_path
 
-    def test_warning_emitted_after_half_timeout(self, project, monkeypatch):
+    def _run(self, project, execute_delay, json_output, timeout):
+        import asyncio as _asyncio
         from evalview.commands.shared import _execute_check_tests
         from evalview.core.config import EvalViewConfig
-
-        monkeypatch.chdir(project)
+        from evalview.core.loader import TestCaseLoader
 
         fake_trace = _make_fake_trace()
         fake_result = _make_fake_result("my-test")
         fake_result.trace = fake_trace
 
-        async def _slow_execute(query, context):
-            import asyncio
-            await asyncio.sleep(0.25)
+        async def _execute(query, context):
+            await _asyncio.sleep(execute_delay)
             return fake_trace
 
         mock_adapter = MagicMock()
-        mock_adapter.execute = _slow_execute
+        mock_adapter.execute = _execute
         mock_evaluator = MagicMock()
         mock_evaluator.evaluate = AsyncMock(return_value=fake_result)
 
-        from evalview.core.loader import TestCaseLoader
-        loader = TestCaseLoader()
-        test_cases = loader.load_from_directory(str(project / "tests"))
-
+        test_cases = TestCaseLoader().load_from_directory(str(project / "tests"))
         config = EvalViewConfig(adapter="http", endpoint="http://example.com")
-
         mock_console = MagicMock()
 
         with (
@@ -266,136 +263,47 @@ class TestSlowAgentWarning:
             patch("evalview.evaluators.evaluator.Evaluator", return_value=mock_evaluator),
             patch("evalview.commands.shared.console", mock_console),
         ):
-            _execute_check_tests(test_cases, config, json_output=False, timeout=0.2)
+            _execute_check_tests(test_cases, config, json_output=json_output, timeout=timeout)
 
-        printed = "\n".join(str(c.args[0]) for c in mock_console.print.call_args_list if c.args)
-        assert "Agent is taking a while" in printed
-        assert "0.1s elapsed" in printed
-        assert "0.2s timeout" in printed
-
-    def test_warning_printed_only_once(self, project, monkeypatch):
-        """Test that warning prints only once per test execution."""
-        from evalview.commands.shared import _execute_check_tests
-        from evalview.core.config import EvalViewConfig
-
-        monkeypatch.chdir(project)
-
-        fake_trace = _make_fake_trace()
-        fake_result = _make_fake_result("my-test")
-        fake_result.trace = fake_trace
-
-        async def _slow_execute(query, context):
-            import asyncio
-            await asyncio.sleep(0.25)
-            return fake_trace
-
-        mock_adapter = MagicMock()
-        mock_adapter.execute = _slow_execute
-        mock_evaluator = MagicMock()
-        mock_evaluator.evaluate = AsyncMock(return_value=fake_result)
-
-        from evalview.core.loader import TestCaseLoader
-        loader = TestCaseLoader()
-        test_cases = loader.load_from_directory(str(project / "tests"))
-
-        config = EvalViewConfig(adapter="http", endpoint="http://example.com")
-
-        mock_console = MagicMock()
-
-        with (
-            patch("evalview.commands.shared._create_adapter", return_value=mock_adapter),
-            patch("evalview.evaluators.evaluator.Evaluator", return_value=mock_evaluator),
-            patch("evalview.commands.shared.console", mock_console),
-        ):
-            _execute_check_tests(test_cases, config, json_output=False, timeout=0.2)
-
-        warning_calls = [
-            c for c in mock_console.print.call_args_list
+        return [
+            str(c.args[0]) for c in mock_console.print.call_args_list
             if c.args and "Agent is taking a while" in str(c.args[0])
         ]
-        assert len(warning_calls) == 1
 
-    def test_warning_suppressed_in_json_output_mode(self, project, monkeypatch):
-        from evalview.commands.shared import _execute_check_tests
-        from evalview.core.config import EvalViewConfig
+    @pytest.mark.parametrize(
+        "execute_delay,json_output,timeout,expected_warnings",
+        [
+            # Slow agent, non-JSON: warning fires exactly once
+            (1.0, False, 0.4, 1),
+            # Slow agent, JSON mode: warning suppressed
+            (1.0, True, 0.4, 0),
+            # Fast agent: completes before the 50% mark, no warning
+            (0.05, False, 2.0, 0),
+        ],
+        ids=["slow-non-json", "slow-json-mode", "fast-no-warning"],
+    )
+    def test_slow_agent_warning_behavior(
+        self, project, monkeypatch, execute_delay, json_output, timeout, expected_warnings
+    ):
+        monkeypatch.chdir(project)
+        warnings = self._run(project, execute_delay, json_output, timeout)
+        assert len(warnings) == expected_warnings
+
+    def test_warning_reports_real_elapsed_and_timeout(self, project, monkeypatch):
+        """Warning message should include a measured elapsed value and the configured timeout."""
+        import re
 
         monkeypatch.chdir(project)
+        warnings = self._run(project, execute_delay=1.0, json_output=False, timeout=0.4)
+        assert len(warnings) == 1
 
-        fake_trace = _make_fake_trace()
-        fake_result = _make_fake_result("my-test")
-        fake_result.trace = fake_trace
-
-        async def _slow_execute(query, context):
-            import asyncio
-            await asyncio.sleep(0.25)
-            return fake_trace
-
-        mock_adapter = MagicMock()
-        mock_adapter.execute = _slow_execute
-        mock_evaluator = MagicMock()
-        mock_evaluator.evaluate = AsyncMock(return_value=fake_result)
-
-        from evalview.core.loader import TestCaseLoader
-        loader = TestCaseLoader()
-        test_cases = loader.load_from_directory(str(project / "tests"))
-
-        config = EvalViewConfig(adapter="http", endpoint="http://example.com")
-
-        mock_console = MagicMock()
-
-        with (
-            patch("evalview.commands.shared._create_adapter", return_value=mock_adapter),
-            patch("evalview.evaluators.evaluator.Evaluator", return_value=mock_evaluator),
-            patch("evalview.commands.shared.console", mock_console),
-        ):
-            _execute_check_tests(test_cases, config, json_output=True, timeout=0.2)
-
-        warning_calls = [
-            c for c in mock_console.print.call_args_list
-            if c.args and "Agent is taking a while" in str(c.args[0])
-        ]
-        assert len(warning_calls) == 0
-
-    def test_no_warning_when_execution_completes_quickly(self, project, monkeypatch):
-        from evalview.commands.shared import _execute_check_tests
-        from evalview.core.config import EvalViewConfig
-
-        monkeypatch.chdir(project)
-
-        fake_trace = _make_fake_trace()
-        fake_result = _make_fake_result("my-test")
-        fake_result.trace = fake_trace
-
-        async def _fast_execute(query, context):
-            import asyncio
-            await asyncio.sleep(0.05)
-            return fake_trace
-
-        mock_adapter = MagicMock()
-        mock_adapter.execute = _fast_execute
-        mock_evaluator = MagicMock()
-        mock_evaluator.evaluate = AsyncMock(return_value=fake_result)
-
-        from evalview.core.loader import TestCaseLoader
-        loader = TestCaseLoader()
-        test_cases = loader.load_from_directory(str(project / "tests"))
-
-        config = EvalViewConfig(adapter="http", endpoint="http://example.com")
-
-        mock_console = MagicMock()
-
-        with (
-            patch("evalview.commands.shared._create_adapter", return_value=mock_adapter),
-            patch("evalview.evaluators.evaluator.Evaluator", return_value=mock_evaluator),
-            patch("evalview.commands.shared.console", mock_console),
-        ):
-            _execute_check_tests(test_cases, config, json_output=False, timeout=0.2)
-
-        warning_calls = [
-            c for c in mock_console.print.call_args_list
-            if c.args and "Agent is taking a while" in str(c.args[0])
-        ]
-        assert len(warning_calls) == 0
+        match = re.search(r"\(([\d.]+)s elapsed of ([\d.]+)s timeout\)", warnings[0])
+        assert match is not None, f"Unexpected warning format: {warnings[0]}"
+        elapsed = float(match.group(1))
+        reported_timeout = float(match.group(2))
+        # Elapsed should be at least the warn_after point (~0.2s) and well under the timeout.
+        assert 0.1 <= elapsed < 0.4
+        assert reported_timeout == 0.4
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-ups to #171 (slow-agent warning). Three issues spotted during review — all small but worth fixing:

- **Real elapsed time, not `timeout * 0.5`.** The warning now tracks `time.monotonic()` from the start of the agent call, so the printed `Xs elapsed` stays accurate if the event loop slips. Previously it just echoed half the timeout as a constant.
- **Snapshot path was missing.** Issue #142 explicitly called out `snapshot_cmd.py` (via `_execute_snapshot_tests`) but the original PR only patched the check path. Now both `evalview check` and `evalview snapshot` surface the warning.
- **DRY.** Pulled the warning-task wrapper into a single `_execute_agent_with_slow_warning` helper in `shared.py`. Both `_run_one` / `_run_one_sequential` in check and the snapshot executor now call one line. Collapsed the four near-identical test cases in `TestSlowAgentWarning` into one parametrized test plus a dedicated elapsed-format assertion, and bumped the sleep margins to reduce CI flakiness.

Credit to @gauravxthakur for the original feature — the `try/finally` + `cancel()` + suppressed `CancelledError` shape was correct, this PR just tightens the edges.

## Test plan

- [x] `pytest tests/test_check_pipeline.py -q` — 11 passed
- [x] `pytest tests/test_check_pipeline.py::TestSlowAgentWarning -v` — 4 passed (3 parametrized + elapsed-format)
- [x] `mypy evalview/commands/shared.py` — clean
- [ ] Manual: `evalview snapshot --timeout 2` against a deliberately slow agent (warning appears)
- [ ] Manual: `evalview check --timeout 2` against a deliberately slow agent (warning appears)
- [ ] Manual: `evalview check --json --timeout 2` — warning suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)