### PR TITLE
Exclude disable-model-invocation skills from skill doctor budget

### DIFF
--- a/docs/SKILLS_TESTING.md
+++ b/docs/SKILLS_TESTING.md
@@ -353,6 +353,28 @@ Diagnoses common issues:
 - Invalid skill structure
 - Missing required fields
 
+#### Manual-only skills (`disable-model-invocation: true`)
+
+Skills with `disable-model-invocation: true` in their frontmatter are
+**manual-only** — Claude Code does not auto-invoke them, so their descriptions
+are **not loaded into the model-invokable skill context** and do not consume
+the 15k character budget.
+
+`evalview skill doctor` excludes these skills from its budget math, but still
+validates them and includes them in duplicate / invalid / multi-line checks.
+
+```yaml
+---
+name: manual-cleanup
+description: Tidy up generated artifacts. Invoked manually only.
+disable-model-invocation: true
+---
+```
+
+When manual-only skills are detected, the doctor summary reports them on a
+dedicated `Manual-only` line so you can tell at a glance which skills are
+excluded from the budget estimate.
+
 ---
 
 ## Related Documentation

--- a/evalview/commands/skill_cmd.py
+++ b/evalview/commands/skill_cmd.py
@@ -265,6 +265,7 @@ def skill_doctor(path: str, recursive: bool, security_scan: bool) -> None:
     names_seen: dict = {}
     invalid_count = 0
     multiline_count = 0
+    manual_only_count = 0
 
     for file_path in files:
         result = SkillValidator.validate_file(file_path)
@@ -272,7 +273,14 @@ def skill_doctor(path: str, recursive: bool, security_scan: bool) -> None:
             name = result.skill.metadata.name
             desc = result.skill.metadata.description
             desc_len = len(desc)
-            total_desc_chars += desc_len
+            # Manual-only skills (disable-model-invocation: true) are not loaded
+            # into Claude's skill-description context, so they don't consume the
+            # 15k char budget. Still count them for duplicates/validation.
+            manual_only = bool(result.skill.metadata.disable_model_invocation)
+            if manual_only:
+                manual_only_count += 1
+            else:
+                total_desc_chars += desc_len
 
             if name in names_seen:
                 names_seen[name].append(file_path)
@@ -287,6 +295,7 @@ def skill_doctor(path: str, recursive: bool, security_scan: bool) -> None:
                 "path": file_path,
                 "desc_chars": desc_len,
                 "valid": True,
+                "manual_only": manual_only,
             })
         else:
             invalid_count += 1
@@ -295,6 +304,7 @@ def skill_doctor(path: str, recursive: bool, security_scan: bool) -> None:
                 "path": file_path,
                 "desc_chars": 0,
                 "valid": False,
+                "manual_only": False,
                 "error": result.errors[0].message if result.errors else "Unknown error",
             })
 
@@ -306,11 +316,14 @@ def skill_doctor(path: str, recursive: bool, security_scan: bool) -> None:
 
     budget_pct = (total_desc_chars / CLAUDE_CODE_CHAR_BUDGET) * 100
     skills_over = max(0, int((total_desc_chars - CLAUDE_CODE_CHAR_BUDGET) / AVG_CHARS_PER_SKILL))
+    # Only model-invokable skills can be "ignored" by a budget overflow.
+    model_invokable_count = max(0, (len(files) - invalid_count) - manual_only_count)
 
     if budget_pct > CHAR_BUDGET_CRITICAL_PCT:
         console.print(
             f"[bold red]⚠️  Character Budget: {budget_pct:.0f}% OVER - "
-            f"Claude is ignoring ~{skills_over} of your {len(files)} skills[/bold red]"
+            f"Claude is ignoring ~{skills_over} of your {model_invokable_count} "
+            f"model-invokable skills[/bold red]"
         )
     elif budget_pct > CHAR_BUDGET_WARNING_PCT:
         console.print(f"[bold yellow]⚠️  Character Budget: {budget_pct:.0f}% - approaching limit[/bold yellow]")
@@ -322,6 +335,11 @@ def skill_doctor(path: str, recursive: bool, security_scan: bool) -> None:
     console.print(f"[bold]Total Skills:[/bold]      {len(files)}")
     console.print(f"[bold]Valid:[/bold]             [green]{len(files) - invalid_count}[/green]")
     console.print(f"[bold]Invalid:[/bold]           [red]{invalid_count}[/red]")
+    if manual_only_count:
+        console.print(
+            f"[bold]Manual-only:[/bold]      [cyan]{manual_only_count}[/cyan] "
+            "[dim](disable-model-invocation — excluded from budget)[/dim]"
+        )
     dup_color = "red" if duplicates else "green"
     console.print(f"[bold]Duplicates:[/bold]        [{dup_color}]{len(duplicates)}[/{dup_color}]")
     ml_color = "yellow" if multiline_count else "green"

--- a/evalview/skills/types.py
+++ b/evalview/skills/types.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from enum import Enum
 from typing import Any, Optional, List, Dict
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class SkillSeverity(str, Enum):
@@ -27,6 +27,9 @@ class SkillValidationError(BaseModel):
 class SkillMetadata(BaseModel):
     """Metadata from SKILL.md frontmatter."""
 
+    # Accept hyphenated aliases from YAML frontmatter (e.g. disable-model-invocation)
+    model_config = ConfigDict(populate_by_name=True)
+
     # Required fields
     name: str = Field(description="Unique identifier for the skill (lowercase, hyphens)")
     description: str = Field(description="What the skill does and when to use it")
@@ -40,6 +43,17 @@ class SkillMetadata(BaseModel):
     tools: Optional[List[str]] = Field(default=None, description="Tools this skill uses")
     model_requirements: Optional[List[str]] = Field(
         default=None, description="Required model capabilities"
+    )
+    # Manual-only skills: Claude Code does not auto-invoke these, so they should
+    # not count toward the skill-description character budget.
+    # Spec key is "disable-model-invocation" (hyphenated) in YAML frontmatter.
+    disable_model_invocation: bool = Field(
+        default=False,
+        alias="disable-model-invocation",
+        description=(
+            "If true, the skill is manual-only (not auto-invoked by the model). "
+            "Excluded from skill doctor's character budget accounting."
+        ),
     )
 
     @field_validator("name", mode="before")

--- a/tests/skills/test_disable_model_invocation.py
+++ b/tests/skills/test_disable_model_invocation.py
@@ -1,0 +1,180 @@
+"""Regression tests for `disable-model-invocation` handling.
+
+Covers:
+- Parser: hyphenated frontmatter key is honored and exposed as
+  ``metadata.disable_model_invocation`` (default False).
+- Skill doctor: manual-only skills are excluded from the 15k character
+  budget math but still counted for validation (files, duplicates, etc).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from evalview.cli import main
+from evalview.skills.parser import SkillParser
+from evalview.skills.validator import SkillValidator
+
+
+# ---------------------------------------------------------------------------
+# Parser behavior
+# ---------------------------------------------------------------------------
+
+
+def _write_skill(
+    directory: Path,
+    *,
+    name: str,
+    description: str,
+    disable_model_invocation: bool | None = None,
+) -> Path:
+    skill_dir = directory / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "---",
+        f"name: {name}",
+        f"description: {description}",
+    ]
+    if disable_model_invocation is not None:
+        lines.append(f"disable-model-invocation: {str(disable_model_invocation).lower()}")
+    lines.extend(["---", "", "# Instructions", "", "Do the thing.", ""])
+    skill_path = skill_dir / "SKILL.md"
+    skill_path.write_text("\n".join(lines))
+    return skill_path
+
+
+def test_parser_defaults_disable_model_invocation_to_false(tmp_path: Path) -> None:
+    skill_path = _write_skill(
+        tmp_path,
+        name="plain-skill",
+        description="A plain skill without the manual-only flag set.",
+    )
+
+    skill = SkillParser.parse_file(str(skill_path))
+
+    assert skill.metadata.disable_model_invocation is False
+
+
+def test_parser_honors_disable_model_invocation_true(tmp_path: Path) -> None:
+    skill_path = _write_skill(
+        tmp_path,
+        name="manual-skill",
+        description="A manual-only skill that should not be auto-invoked.",
+        disable_model_invocation=True,
+    )
+
+    skill = SkillParser.parse_file(str(skill_path))
+
+    assert skill.metadata.disable_model_invocation is True
+
+
+def test_parser_honors_disable_model_invocation_false(tmp_path: Path) -> None:
+    skill_path = _write_skill(
+        tmp_path,
+        name="auto-skill",
+        description="An auto-invokable skill with the flag explicitly false.",
+        disable_model_invocation=False,
+    )
+
+    skill = SkillParser.parse_file(str(skill_path))
+
+    assert skill.metadata.disable_model_invocation is False
+
+
+def test_validator_accepts_manual_only_skill(tmp_path: Path) -> None:
+    skill_path = _write_skill(
+        tmp_path,
+        name="manual-skill",
+        description="Manual-only skill — validator must still treat it as valid.",
+        disable_model_invocation=True,
+    )
+
+    result = SkillValidator.validate_file(str(skill_path))
+
+    assert result.valid, result.errors
+    assert result.skill is not None
+    assert result.skill.metadata.disable_model_invocation is True
+
+
+# ---------------------------------------------------------------------------
+# Skill doctor budget exclusion
+# ---------------------------------------------------------------------------
+
+
+def _long_description(prefix: str, target_chars: int) -> str:
+    # Keep it single-line (multiline descriptions are validation warnings),
+    # avoid XML-like tags or colons (which would confuse YAML parsing as an
+    # unquoted mapping value), and stay well under the 1024 per-skill max.
+    base = f"{prefix} - " + "alpha beta gamma delta epsilon zeta eta theta iota kappa "
+    padded = (base * ((target_chars // len(base)) + 1))[:target_chars]
+    return padded.replace("\n", " ").strip()
+
+
+def test_doctor_excludes_manual_only_skills_from_budget(tmp_path: Path) -> None:
+    """Manual-only skills must not push the budget over.
+
+    Two ~900-char auto-invoke skills (~1.8k chars) stay well under the 15k
+    budget. If we additionally add many manual-only skills whose descriptions
+    *would* exceed the budget when counted, the doctor must still report the
+    budget as green and must not claim any skill is "INVISIBLE".
+    """
+    # Two normal skills — safely under budget on their own.
+    _write_skill(
+        tmp_path,
+        name="auto-one",
+        description=_long_description("auto-one", 900),
+    )
+    _write_skill(
+        tmp_path,
+        name="auto-two",
+        description=_long_description("auto-two", 900),
+    )
+    # Many manual-only skills whose descriptions, if counted, would blow the
+    # 15k budget several times over.
+    for i in range(30):
+        _write_skill(
+            tmp_path,
+            name=f"manual-{i:02d}",
+            description=_long_description(f"manual-{i}", 900),
+            disable_model_invocation=True,
+        )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["skill", "doctor", str(tmp_path), "-r"])
+
+    assert result.exit_code == 0, result.output
+    # Under budget → green summary banner, no "ignoring" / "INVISIBLE" noise.
+    assert "Character Budget:" in result.output
+    assert "OVER" not in result.output, result.output
+    assert "INVISIBLE" not in result.output, result.output
+    assert "ignoring" not in result.output, result.output
+    # Manual-only line is surfaced with the right count and context.
+    assert "Manual-only:" in result.output
+    assert "30" in result.output
+    assert "disable-model-invocation" in result.output
+    # All 32 skills are counted as valid (validation is not skipped).
+    assert "Total Skills:      32" in result.output
+
+
+def test_doctor_counts_auto_invoke_skills_in_budget(tmp_path: Path) -> None:
+    """Sanity check: without the flag, the same skills DO exceed the budget.
+
+    This proves the exclusion in ``test_doctor_excludes_manual_only_skills_from_budget``
+    is load-bearing — the descriptions themselves are heavy enough to trip the
+    budget when they are not marked manual-only.
+    """
+    for i in range(30):
+        _write_skill(
+            tmp_path,
+            name=f"auto-{i:02d}",
+            description=_long_description(f"auto-{i}", 900),
+        )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["skill", "doctor", str(tmp_path), "-r"])
+
+    assert result.exit_code == 0, result.output
+    assert "OVER" in result.output, result.output
+    assert "model-invokable skills" in result.output, result.output


### PR DESCRIPTION
## Problem

`evalview skill doctor` currently counts every valid skill description toward the Claude Code character budget. But skills declared with `disable-model-invocation: true` are manual-only — Claude Code does **not** load their descriptions into context, so they cannot consume that budget. Counting them inflates the estimate and produces false "Claude is ignoring ~X skills" warnings.

## Evidence

From the official Claude Code skills docs — [code.claude.com/docs/en/skills](https://code.claude.com/docs/en/skills), section *Control who invokes a skill*:

> | Frontmatter                      | You can invoke | Claude can invoke | When loaded into context                                         |
> | :------------------------------- | :------------- | :---------------- | :--------------------------------------------------------------- |
> | (default)                        | Yes            | Yes               | Description always in context, full skill loads when invoked     |
> | `disable-model-invocation: true` | Yes            | No                | **Description not in context**, full skill loads when you invoke |
> | `user-invocable: false`          | No             | Yes               | Description always in context, full skill loads when invoked     |

Same page, *Restrict Claude's skill access*:

> **Hide individual skills** by adding `disable-model-invocation: true` to their frontmatter. **This removes the skill from Claude's context entirely.**

And *Skill descriptions are cut short* (troubleshooting) scopes the budget specifically to descriptions loaded into context:

> Skill descriptions are loaded into context so Claude knows what's available. ... descriptions are shortened to fit the character budget ... To raise the limit, set the `SLASH_COMMAND_TOOL_CHAR_BUDGET` environment variable.

Together: a skill whose description is not in context cannot consume the budget that governs in-context descriptions. The upstream issue [anthropics/claude-code#19141](https://github.com/anthropics/claude-code/issues/19141) quotes the same table in its resolution, so this is canonical documented behavior.

Nuance: `user-invocable: false` is **not** equivalent — its description is still always in context. This PR therefore keys exclusion strictly on `disable-model-invocation`.

## What this PR does

- adds frontmatter support for `disable-model-invocation` (hyphenated YAML alias on `SkillMetadata.disable_model_invocation`)
- excludes those skills from budget accounting in `skill doctor` while still counting them for validation, duplicates, multi-line checks, and invalid-skill reporting
- surfaces a `Manual-only` summary line when such skills are present, and retitles the overage message to "~X of your Y **model-invokable** skills"
- updates `docs/SKILLS_TESTING.md`
- adds regression tests (`tests/skills/test_disable_model_invocation.py`): parser default/true/false, validator still accepts, doctor excludes from budget, and a negative-case sanity check that proves the exclusion is load-bearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)