### PR TITLE
fix(dogfood): align tests 01/02 with CI LLM latency and tool usage

### DIFF
--- a/dogfood/test-cases/01-list-adapters.yaml
+++ b/dogfood/test-cases/01-list-adapters.yaml
@@ -7,6 +7,8 @@ input:
   query: "What adapters does EvalView support?"
 
 expected:
+  tools:
+    - evalview_cli
   output:
     contains:
       - "http"
@@ -19,4 +21,4 @@ expected:
 thresholds:
   min_score: 70
   max_cost: 0.05
-  max_latency: 30000
+  max_latency: 180000

--- a/dogfood/test-cases/02-explain-test-case.yaml
+++ b/dogfood/test-cases/02-explain-test-case.yaml
@@ -20,4 +20,4 @@ expected:
 thresholds:
   min_score: 70
   max_cost: 0.05
-  max_latency: 30000
+  max_latency: 180000


### PR DESCRIPTION
## Summary

The last 5 daily dogfood runs (#181, #184, #187, #190, #191) kept creating failure issues. Root-causing the two clearest patterns and aligning tests 01 & 02 with the thresholds that tests 03 & 04 already use.

### What's failing

**Test 01 (`List Adapters Knowledge`)** — failing on #190 and #191 with two recurring symptoms:
- `Unexpected tools: evalview_cli` — the test declares no `expected.tools`, but the agent legitimately calls `evalview_cli` to fetch real adapter data. Tests 03 & 04 already declare `tools: [evalview_cli]`; test 01 should too.
- `Latency exceeded: 76610ms > 30000ms` / `47830ms > 30000ms` — real OpenAI round-trips on GitHub runners land in the 47–76s range. The 30s ceiling is simply too tight. Tests 03 & 04 use `180000ms` (set by `dd32b5a fix(dogfood): ... loosen 04 thresholds`).

**Test 02 (`Test Case Structure`)** — same 30s latency ceiling, same flake risk. Preemptive alignment with 03/04.

### What's NOT addressed

- #184 (`Output Quality: 60/100 ✗` on test 03) and #181 (test 03 related) have a different root cause: the LLM-judge scores terse valid answers low. That needs a separate change (richer query, relaxed per-evaluator threshold, or expanded `contains` checks) — out of scope for this PR.

## Changes

- `dogfood/test-cases/01-list-adapters.yaml`: add `tools: [evalview_cli]`, `max_latency` 30000 → 180000
- `dogfood/test-cases/02-explain-test-case.yaml`: `max_latency` 30000 → 180000

## Test plan

- [ ] Next daily dogfood run (or manual `workflow_dispatch`) shows tests 01 & 02 passing
- [ ] Close #190, #191, and #187 (if its failing test was 01/02) once green
- [ ] Follow up separately on #181 / #184 for the test 03 output-quality flake