### PR TITLE
feat(observability): add optional hint to GamingFlag + decision_type descriptions

### DIFF
--- a/evalview/core/benchmark_hardening.py
+++ b/evalview/core/benchmark_hardening.py
@@ -67,20 +67,36 @@ class FlagSeverity(str, Enum):
 
 @dataclass
 class GamingFlag:
-    """A single anti-gaming flag raised during evaluation."""
+    """A single anti-gaming flag raised during evaluation.
+
+    ``hint`` is a one-sentence recommendation to a human reviewer —
+    what to do about this flag in concrete terms ("quarantine this
+    test until you verify the tool list is complete"). It's optional
+    so legacy flags without actionable guidance still emit cleanly.
+    Cloud renders it verbatim in the TrustIndicator popover so the
+    cloud UI doesn't have to invent semantics that belong here.
+    """
 
     check: GamingCheck
     severity: FlagSeverity
     description: str
     evidence: Dict[str, Any] = field(default_factory=dict)
+    hint: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        out: Dict[str, Any] = {
             "check": self.check.value,
             "severity": self.severity.value,
             "description": self.description,
             "evidence": self.evidence,
         }
+        # Only include `hint` when present so wire payloads stay compact
+        # and downstream schemas that don't know about the field still
+        # validate — cloud's Zod schema for trust_scores treats unknown
+        # keys permissively, but smaller payloads are still preferred.
+        if self.hint is not None:
+            out["hint"] = self.hint
+        return out
 
 
 @dataclass
@@ -259,6 +275,10 @@ def _check_config_leakage(trace: ExecutionTrace) -> List[GamingFlag]:
             evidence={
                 "leaked_paths": leaked_paths[:10],
             },
+            hint=(
+                "Restrict filesystem access in the agent's sandbox so test "
+                "fixtures and golden outputs can't be read at inference time."
+            ),
         ))
 
     return flags
@@ -295,6 +315,11 @@ def _check_score_without_work(
                 "tool_call_count": len(trace.steps),
                 "min_expected_tools": min_tools,
             },
+            hint=(
+                "Rephrase the test prompt so the agent can't answer from "
+                "training priors alone, or raise the judge scorer's "
+                "reasoning requirement."
+            ),
         ))
 
     return flags

--- a/evalview/core/observability.py
+++ b/evalview/core/observability.py
@@ -49,12 +49,24 @@ class AnomalyReportDict(TypedDict):
     summary: str
 
 
-class TrustFlagDict(TypedDict):
-    """Schema for a single gaming flag in the trust report."""
+class TrustFlagDict(TypedDict, total=False):
+    """Schema for a single gaming flag in the trust report.
+
+    ``hint`` is optional — when present, it carries a one-sentence
+    recommendation for a human reviewer ("quarantine this test",
+    "verify the tool list passed to the agent"). Cloud surfaces it
+    verbatim in the TrustIndicator popover so the UX doesn't have to
+    invent meaning that belongs on the OSS side.
+
+    Fields marked required via total=False convention: check / severity
+    / description / evidence are always emitted by GamingFlag.to_dict();
+    ``hint`` is emitted only when the check defines one.
+    """
     check: str
     severity: str
     description: str
     evidence: Dict[str, Any]
+    hint: str
 
 
 class TrustReportDict(TypedDict):

--- a/evalview/core/rationale.py
+++ b/evalview/core/rationale.py
@@ -45,6 +45,18 @@ from evalview.core.types import (
 logger = logging.getLogger(__name__)
 
 
+# Canonical plain-language descriptions for each decision_type value.
+# Shared by local HTML replay, CI comments, and cloud UI tooltips so every
+# surface explains the enum the same way. Keep keys in sync with the
+# ``DecisionType`` literal in :mod:`evalview.core.types`.
+DECISION_TYPE_DESCRIPTIONS: dict[str, str] = {
+    "tool_choice": "Agent picked a specific tool from the tools available to it.",
+    "branch":      "Agent chose a control-flow path — a node transition in LangGraph / CrewAI, or an if/else in a handwritten agent.",
+    "refusal":     "Agent declined to act on the input. Captured explicitly so policy-trained refusals don't look like silent failures.",
+    "retry":       "Agent re-attempted a step after a failure. Surfaces retry loops that could mask a systematic bug.",
+}
+
+
 def compute_input_hash(
     prompt: Optional[str] = None,
     tool_state: Optional[Any] = None,


### PR DESCRIPTION
## Summary

Lifts plain-language meaning for trust flags and decision types up to the OSS source of truth so cloud surfaces (TrustIndicator, Rationale tab) don't have to invent it.

- `TrustFlagDict` (`observability.py`): add optional `hint` field (uses `total=False` TypedDict semantics so existing consumers stay valid).
- `GamingFlag` (`benchmark_hardening.py`): add `hint: Optional[str]`; `to_dict()` emits it only when set so payloads stay compact.
- Populate hints on `CONFIG_LEAKAGE` and `SCORE_WITHOUT_WORK` as concrete examples of the pattern (future checks should follow suit).
- `DECISION_TYPE_DESCRIPTIONS` (`rationale.py`): canonical one-sentence explainers for `tool_choice` / `branch` / `refusal` / `retry`, so HTML replay, CI comments, and cloud UI render the same copy.

Backwards-compatible on the wire: cloud's Zod schema for `trust_scores` accepts unknown keys, so this lands without a cloud schema bump.

Companion cloud PR: https://github.com/hidai25/evalview-cloud/pull/new/claude/world-class-polish-2026-04 (consumes `hint` in TrustIndicator).

## Test plan

- [x] `pytest tests/test_benchmark_hardening.py tests/test_rationale.py tests/test_observability_regressions.py` — 98 passed
- [x] Smoke import: `GamingFlag(..., hint="do y").to_dict()` emits `hint`; `DECISION_TYPE_DESCRIPTIONS` populated
- [ ] Full `pytest` suite (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)