### PR TITLE
fix(cloud): align push payload with cloud schema v2

### DIFF
--- a/docs/CLOUD.md
+++ b/docs/CLOUD.md
@@ -1,0 +1,110 @@
+# EvalView Cloud — what it is, what it stores, what it never runs
+
+> Optional dashboard for teams. The CLI stays fully local; cloud is
+> additive — runs flow in via HTTP, analytics flow back, nothing is
+> ever required.
+
+EvalView is a local-first CLI. `evalview check`, `evalview simulate`,
+`evalview monitor`, `evalview autopr` — all run on your machine, write
+to `.evalview/`, and never touch the network unless you tell them to.
+
+EvalView Cloud is the optional team layer on top of that:
+
+- **A persistent home for runs.** Trends, ship decisions, drift
+  charts, and PR comment archives across machines and CI jobs.
+- **Cross-run analytics for rationale capture.** Decision drift,
+  novel-decision-type alerts, branch causal graphs.
+- **Slack/email digests.** Suppress noise via the same n=2
+  confirmation gate the CLI already uses locally.
+- **Public share links** for simulations, so you can show a teammate
+  a what-if outcome without granting account access.
+
+## What cloud explicitly does not do
+
+This is the load-bearing invariant: **cloud holds no API keys, runs
+no agents, and runs no simulations.** Everything that costs money,
+makes a model call, or executes a tool happens locally. Cloud only
+persists and aggregates the structured payloads the CLI emits.
+
+Concretely:
+
+- Cloud never runs `evalview check`, `evalview simulate`, or any
+  adapter. It receives the resulting `EvaluationResult` payload over
+  `POST /api/v1/results` and stores it.
+- Cloud never replays traces or scores responses. The judge model,
+  if any, is configured locally and runs locally.
+- Cloud never pulls from your repo or CI. The CLI pushes; cloud
+  receives. There is no inverse channel.
+
+This boundary is enforced both in code (the cloud route deliberately
+skips the drift/quarantine fan-out for `run_type="simulation"`
+because mock-driven outcomes shouldn't poison the trend line) and in
+the schema — the simulation payload is an opaque JSON the cloud only
+walks for rendering, never for re-execution.
+
+## Connecting the CLI
+
+```bash
+evalview login   # opens a browser to evalview.com, drops a token in ~/.evalview/config.toml
+evalview check   # subsequent runs auto-push to cloud after local eval finishes
+```
+
+The push is best-effort and synchronous-but-bounded: up to 3 retries
+with exponential backoff over ~15 seconds. Auth/billing errors fail
+immediately without retry. A failed push never blocks the CLI exit
+code — local eval is the source of truth.
+
+To opt out at any time: `evalview logout`, or unset
+`EVALVIEW_API_TOKEN`. The CLI is fully functional without cloud.
+
+## What's on the wire
+
+`evalview/cloud/push.py::push_result()` is the single push site.
+The payload is documented inline; the bounded fields are:
+
+| Field | Owner | Cap |
+|---|---|---|
+| `run_type` | OSS — `"standard"` or `"simulation"` | enum |
+| `summary` + `diffs` | OSS gate result, mirrored verbatim | per-test diff blob ≤ ~1 MB |
+| `verdict` | OSS — see `evalview/core/verdict.py` | 4-tier enum |
+| `behavioral_anomalies` / `trust_scores` / `coherence_analysis` | OSS observability per-test arrays | aggregated to top-N per push |
+| `simulation` | OSS engine output — opaque to cloud | run-level |
+| `rationale_events` | OSS adapter capture hook | 500/run, 4 KB/event (caps in `evalview/core/rationale.py`) |
+
+## When OSS and cloud need to move together
+
+A small set of constants and enums must stay in lockstep across the
+two repos. When you change them on the OSS side, coordinate a cloud
+deploy in the same PR cycle:
+
+| Surface | OSS source of truth | Cloud mirror |
+|---|---|---|
+| 4-tier verdict enum | `evalview/core/verdict.py::Verdict` | `src/lib/verdict.ts::Verdict` |
+| Verdict headline strings | `evalview/core/verdict.py::_HEADLINE` | `src/lib/verdict.ts::HEADLINES` |
+| Rationale caps | `RATIONALE_MAX_EVENTS_PER_RUN`, `RATIONALE_MAX_TEXT_BYTES` | `src/lib/result-schemas.ts` |
+| `decision_type` enum | `evalview/core/types.py::DecisionType` | Zod enum + DB CHECK constraint |
+| `decision_type` descriptions | `evalview/core/rationale.py::DECISION_TYPE_DESCRIPTIONS` | `src/lib/rationale-decision-types.ts` |
+| Observability schema version | `evalview/core/observability.py::OBSERVABILITY_SCHEMA_VERSION` | accepted on the wire, no version-gating yet |
+
+The cloud schema is intentionally tolerant where it can be (loose
+`mocks_applied` arrays, aliasing `run_type="check"` → `"standard"`)
+so an OSS upgrade ahead of a cloud deploy never bricks ingest.
+
+## Privacy posture
+
+- Trace contents (prompts, completions, tool args) live in
+  `result_json` and `diffs[*].diff_json`. Both are stored verbatim.
+  If you're testing on customer data, scrub before push or skip
+  cloud entirely — `evalview check` works fully without it.
+- Cloud never stores raw API keys. Tokens minted by `evalview
+  login` are scoped per-org and revocable from the dashboard.
+- Public simulation share links (`/share/simulations/<slug>`) are
+  the one anonymous-readable surface. Slugs are 128-bit random;
+  admins create and revoke them.
+
+## Related
+
+- `docs/RATIONALE.md` — what gets sent under `rationale_events`
+- `docs/SIMULATE.md` — what gets sent under `simulation`
+- `docs/OPERATING_MODEL.md` — how teams run the loop end-to-end
+- `evalview/cloud/push.py` — the canonical push site

--- a/evalview/cloud/push.py
+++ b/evalview/cloud/push.py
@@ -271,7 +271,11 @@ def push_result(gate_result: Any) -> Optional[str]:
 
         # Discriminator lets cloud route simulation runs to the
         # /runs/[id]/simulation tab without guessing from the body.
-        run_type = "simulation" if gate_result.raw_json.get("simulation") else "check"
+        # Cloud's Zod accepts "standard" | "simulation"; we send
+        # "standard" (the older "check" alias still validates via a
+        # cloud-side compatibility shim, but new pushes use the
+        # canonical name).
+        run_type = "simulation" if gate_result.raw_json.get("simulation") else "standard"
 
         payload = {
             "run_id": gate_result.raw_json.get("run_id", hashlib.md5(
@@ -306,8 +310,40 @@ def push_result(gate_result: Any) -> Optional[str]:
             "result_json": gate_result.raw_json,
         }
 
-        # Include observability signals via the canonical ObservabilitySummary
+        # Observability — sent in three complementary shapes so cloud
+        # populates both the per-test detail panels and the aggregate
+        # columns on the runs row:
+        #
+        #   1. Per-test arrays at the top level. These keys
+        #      (`behavioral_anomalies`, `trust_scores`,
+        #      `coherence_analysis`) are what cloud's /api/v1/results
+        #      route reads to fill test_diffs.anomaly_report,
+        #      trust_score, coherence_score, coherence_report. Names
+        #      come from check_display.py's --json output; we forward
+        #      them verbatim out of raw_json.
+        #   2. Aggregate count blocks at the top level
+        #      (`low_trust_tests`, `coherence_issues`) so cloud's
+        #      runs.low_trust_count / coherence_issue_count columns
+        #      populate without re-walking the per-test arrays.
+        #   3. The legacy `observability` envelope is still attached
+        #      for older cloud routes / digest renderers that read it.
+        for key in ("behavioral_anomalies", "trust_scores", "coherence_analysis"):
+            value = gate_result.raw_json.get(key)
+            if value:
+                payload[key] = value
+
         obs = gate_result.observability
+        if obs.low_trust_count:
+            payload["low_trust_tests"] = {
+                "count": obs.low_trust_count,
+                "tests": obs.low_trust_tests[:10],
+            }
+        if obs.coherence_issue_count:
+            payload["coherence_issues"] = {
+                "count": obs.coherence_issue_count,
+                "tests": obs.coherence_tests[:10],
+            }
+
         obs_payload = obs.to_payload()
         if obs_payload:
             payload["observability"] = obs_payload


### PR DESCRIPTION
## Summary

`evalview/cloud/push.py` was out of sync with the cloud schema in two
places — both surface as silent or hard failures on the cloud side.

- **`run_type="check"` → cloud rejects with 400.** Cloud's Zod accepts
  `"standard" | "simulation"`. Every v0.7+ standard-run push currently
  fails ingest. Switched to `"standard"`. (Cloud also got a
  compatibility shim for `"check"` so older clients keep working.)
- **Per-test observability never reaches cloud columns.** Cloud reads
  `behavioral_anomalies` / `trust_scores` / `coherence_analysis` at
  the top level of the payload to fill `test_diffs.anomaly_report`,
  `trust_score`, `coherence_score`, `coherence_report`. Push was only
  attaching the aggregate `observability` envelope, so per-test
  detail panels were empty even when the CLI computed the data.
  Forward those arrays from `raw_json`, and add `low_trust_tests` /
  `coherence_issues` aggregate blocks so the run-level columns
  populate too.

The legacy `observability` envelope is still attached for backwards
compatibility with older cloud routes / digest renderers.

Also adds **`docs/CLOUD.md`**, which `docs/RATIONALE.md:89` has been
linking at since April but didn't exist. Documents what cloud stores,
the "cloud never runs the engine" invariant, and the small set of
constants that need lockstep updates between repos (verdict tiers,
rationale caps, `decision_type` descriptions, etc.).

## Test plan

- [x] `python -m py_compile evalview/cloud/push.py`
- [x] `ruff check evalview/cloud/push.py`
- [ ] Smoke test against a local cloud: `EVALVIEW_CLOUD_URL=http://localhost:3000/api/v1 evalview check tests/` and confirm 200/201 (was 400) and that the resulting run row has `low_trust_count` / `coherence_issue_count` set when present
- [ ] Re-run an integration that captures `trust_scores` and verify the per-test panels render in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)