### PR TITLE
chore(validate): apply review follow-ups to PR #195

### DIFF
--- a/evalview/commands/validate_cmd.py
+++ b/evalview/commands/validate_cmd.py
@@ -6,12 +6,14 @@ import json
 import sys
 import time
 from pathlib import Path
+from typing import Any, Dict, List, Tuple
 
 import click
 import yaml
 from pydantic import ValidationError
 
 from evalview.commands.shared import console
+from evalview.core.loader import CONFIG_FILE_PATTERNS
 from evalview.core.types import TestCase
 from evalview.telemetry.decorators import track_command
 
@@ -31,9 +33,7 @@ except ImportError:  # pragma: no cover - py<3.11
 # File extensions recognized as test cases. TOML is only collected when a
 # loader is available so we don't surface false "missing dependency" errors
 # for unrelated TOML in the directory (e.g. pyproject.toml).
-_TEST_EXTENSIONS: tuple[str, ...] = (".yaml", ".yml") + ((".toml",) if _toml_loader is not None else ())
-# Config files (mirrored from evalview/core/loader.py CONFIG_FILE_PATTERNS)
-_CONFIG_FILES = {"config.yaml", "config.yml", ".evalview.yaml", ".evalview.yml"}
+_TEST_EXTENSIONS: Tuple[str, ...] = (".yaml", ".yml") + ((".toml",) if _toml_loader is not None else ())
 
 
 @click.command("validate")
@@ -72,7 +72,7 @@ def validate(path: str, output_json: bool) -> None:
         sys.exit(0)
 
     start = time.time()
-    results: list[dict] = []
+    results: List[Dict[str, Any]] = []
     has_errors = False
 
     for fp in files:
@@ -108,18 +108,18 @@ def validate(path: str, output_json: bool) -> None:
     sys.exit(1 if has_errors else 0)
 
 
-def _collect_test_files(path_obj: Path) -> list[Path]:
+def _collect_test_files(path_obj: Path) -> List[Path]:
     if path_obj.is_file():
         return [path_obj] if path_obj.suffix.lower() in _TEST_EXTENSIONS else []
     if not path_obj.is_dir():
         return []
-    files: list[Path] = []
+    files: List[Path] = []
     for ext in _TEST_EXTENSIONS:
         files.extend(path_obj.rglob(f"*{ext}"))
-    return sorted(f for f in files if f.is_file() and f.name.lower() not in _CONFIG_FILES)
+    return sorted(f for f in files if f.is_file() and f.name.lower() not in CONFIG_FILE_PATTERNS)
 
 
-def _validate_file(file_path: Path) -> list[dict]:
+def _validate_file(file_path: Path) -> List[Dict[str, Any]]:
     """Return list of error dicts (empty list = valid)."""
     try:
         if file_path.suffix.lower() == ".toml":
@@ -137,11 +137,14 @@ def _validate_file(file_path: Path) -> list[dict]:
             with open(file_path, "rb") as f:
                 data = _toml_loader.load(f)
         else:
-            with open(file_path, "r") as f:
+            with open(file_path, "r", encoding="utf-8") as f:
                 data = yaml.safe_load(f)
     except yaml.YAMLError as exc:
         return [{"field": None, "message": f"YAML parse error: {exc}", "type": "parse"}]
-    except Exception as exc:  # tomllib.TOMLDecodeError, IOError, etc.
+    # TOMLDecodeError (both stdlib tomllib and the tomli backport) subclasses
+    # ValueError; UnicodeDecodeError likewise — so this pair covers parse and
+    # encoding failures without swallowing programming bugs.
+    except (OSError, ValueError) as exc:
         return [{"field": None, "message": f"Parse error: {exc}", "type": "parse"}]
 
     if not isinstance(data, dict):
@@ -179,7 +182,7 @@ def _validate_file(file_path: Path) -> list[dict]:
         ]
 
 
-def _render_human_output(results: list[dict], elapsed_ms: float) -> None:
+def _render_human_output(results: List[Dict[str, Any]], elapsed_ms: float) -> None:
     valid_count = sum(1 for r in results if r["valid"])
     error_count = len(results) - valid_count
 

--- a/tests/test_validate_cmd.py
+++ b/tests/test_validate_cmd.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import json
 
+import pytest
 from click.testing import CliRunner
 
-from evalview.commands.validate_cmd import validate
+from evalview.commands.validate_cmd import _toml_loader, _validate_file, validate
+
+requires_toml = pytest.mark.skipif(
+    _toml_loader is None,
+    reason="needs Python 3.11+ stdlib tomllib or the tomli backport",
+)
 
 
 def _good_yaml() -> str:
@@ -90,3 +96,83 @@ def test_validate_no_files_exits_zero(tmp_path):
     runner = CliRunner()
     result = runner.invoke(validate, [str(tmp_path)])
     assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Coverage for branches that the original PR's test suite did not exercise:
+# TOML happy/sad path, the "top-level must be a mapping" structure error,
+# the schema_error fallback for TestCase pre-validators, and the dead-code
+# missing-dependency message (kept defensively even though file collection
+# currently shields it from production reach).
+# ---------------------------------------------------------------------------
+
+
+@requires_toml
+def test_validate_toml_valid_file(tmp_path):
+    f = tmp_path / "ok.toml"
+    f.write_text(
+        'name = "test_case"\n'
+        "[input]\n"
+        'query = "hello"\n'
+        "[expected]\n"
+        "tools = []\n"
+        "[thresholds]\n"
+        "min_score = 0\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(validate, [str(f)])
+    assert result.exit_code == 0
+
+
+@requires_toml
+def test_validate_toml_schema_error(tmp_path):
+    # No `name` field — TestCase requires it.
+    f = tmp_path / "bad.toml"
+    f.write_text("[input]\nquery = 'hello'\n")
+    runner = CliRunner()
+    result = runner.invoke(validate, [str(f), "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["results"][0]["errors"]
+
+
+def test_validate_top_level_not_mapping(tmp_path):
+    # YAML list at top level — TestCase expects a mapping.
+    f = tmp_path / "list.yaml"
+    f.write_text("- a\n- b\n")
+    runner = CliRunner()
+    result = runner.invoke(validate, [str(f), "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["results"][0]["errors"][0]["type"] == "structure"
+
+
+def test_validate_schema_construction_error(tmp_path):
+    # Multi-turn pre-validator (_populate_input_from_first_turn) raises
+    # KeyError when turns[0] lacks `query`. This must be caught and reported
+    # as schema_error rather than aborting the whole validate run.
+    f = tmp_path / "bad_multiturn.yaml"
+    f.write_text(
+        "name: bad\n"
+        "turns:\n"
+        "  - context: missing-query-field\n"
+        "  - query: second\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(validate, [str(f), "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["results"][0]["errors"][0]["type"] == "schema_error"
+
+
+def test_validate_file_missing_toml_loader_message(tmp_path, monkeypatch):
+    # Direct call to _validate_file: when no TOML loader is available, the
+    # caller (a future refactor or a hand-built path) gets a clear, actionable
+    # message rather than a confusing AttributeError on `_toml_loader.load`.
+    monkeypatch.setattr("evalview.commands.validate_cmd._toml_loader", None)
+    f = tmp_path / "x.toml"
+    f.write_text("name = 'x'\n")
+    errors = _validate_file(f)
+    assert len(errors) == 1
+    assert errors[0]["type"] == "missing_dependency"
+    assert "tomllib" in errors[0]["message"] or "tomli" in errors[0]["message"]


### PR DESCRIPTION
Small corrections to the validate command merged in #195. Five changes; #1 and #2 are real bug fixes, the rest are convention/coverage hardening.

## Changes

| # | What | Why |
|---|------|-----|
| 1 | Import `CONFIG_FILE_PATTERNS` from `evalview.core.loader` instead of redeclaring | Original PR commented \"(mirrored from loader.py)\" — exact silent-drift trap the new CONTRIBUTING.md rule (added in aa72020) warns against. If the loader gains a config pattern, validate now picks it up. |
| 2 | Add `encoding=\"utf-8\"` to YAML `open()` | Without it Python falls back to `locale.getpreferredencoding()` — cp1252 on Windows, EUC-JP on some JP locales. Test prompts in non-ASCII would silently fail validation on those systems. |
| 3 | Convert `tuple[str, ...]`/`list[dict]`/`list[Path]` → `Tuple`/`List`/`Dict[str, Any]` | Project convention (CLAUDE.md + CONTRIBUTING.md): Python 3.9 capitalized typing imports across the codebase. `from __future__ import annotations` masked the runtime impact but consistency wins. |
| 4 | Narrow `except Exception` → `except (OSError, ValueError)` | Both `tomllib.TOMLDecodeError` and `tomli.TOMLDecodeError` subclass `ValueError`, as does `UnicodeDecodeError` — covers the documented intent (\"TOMLDecodeError, IOError, etc.\") without swallowing programming bugs. |
| 5 | Add 5 tests for previously-uncovered branches | TOML happy/sad path (skipif no loader), top-level-not-a-mapping structure error, schema construction error fallback (the `KeyError` catch from `TestCase._populate_input_from_first_turn`), and a direct `_validate_file` call exercising the missing-TOML-loader branch. |

## Note on the missing-TOML-loader branch

`.toml` is excluded from `_TEST_EXTENSIONS` at module import time when no loader is available, so the dead-dependency error message in `_validate_file` is currently unreachable through the CLI. Test calls `_validate_file` directly — the message is kept as defense against future discovery refactors that always include `.toml`.

## Verification

- 13 tests pass (was 8)
- ruff clean
- mypy clean across 212 source files
- Full suite: 1505 passing

## Test plan
- [x] \`pytest tests/test_validate_cmd.py\` — 13 pass locally
- [x] \`ruff check evalview/commands/validate_cmd.py tests/test_validate_cmd.py\` — clean
- [x] \`mypy evalview/commands/validate_cmd.py\` — clean
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)