### PR TITLE
ci: bump checkout to v5 and setup-python to v6 for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -46,10 +46,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 
@@ -70,10 +70,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 
@@ -98,10 +98,10 @@ jobs:
     needs: [test, lint]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 

--- a/.github/workflows/evalview.yml
+++ b/.github/workflows/evalview.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,10 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 


### PR DESCRIPTION
## Summary

GitHub deprecated Node 20 in JavaScript actions. Without this bump, every CI run currently emits a deprecation warning, and starting **June 2, 2026** all actions get force-upgraded to Node 24 regardless of what they declare. On **September 16, 2026** Node 20 is removed entirely from runners.

`actions/checkout@v4` and `actions/setup-python@v5` ship with Node 20 binaries. Their `@v5` / `@v6` majors ship with Node 24 native and are otherwise backwards-compatible with the existing inputs we use.

## Changes

| File | Bumps |
|------|-------|
| `.github/workflows/ci.yml` | 4× checkout, 4× setup-python |
| `.github/workflows/dogfood.yml` | 1× checkout, 1× setup-python |
| `.github/workflows/publish.yml` | 1× checkout, 1× setup-python |
| `.github/workflows/evalview.yml` | 1× checkout, 1× setup-python |

14 line changes total, no logic touched.

## Out of scope

Other actions present in the workflows (`codecov-action@v4`, `upload-artifact@v4`, `github-script@v7`) were not flagged by the deprecation notice and are left for a future bump if/when GitHub flags them.

## Test plan
- [ ] CI green on this PR — proves the new majors actually work on our matrix
- [ ] No deprecation warning in the CI logs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)