### PR TITLE
chore(diff): apply review follow-ups to PR #198

### DIFF
--- a/evalview/commands/diff_cmd.py
+++ b/evalview/commands/diff_cmd.py
@@ -3,46 +3,48 @@ from __future__ import annotations
 
 import difflib
 import json
-import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import click
+from rich.table import Table
 
 from evalview.commands.shared import console
 from evalview.telemetry.decorators import track_command
 
 
 def _load_result_file(path: Path) -> List[Dict[str, Any]]:
+    """Load a result file, raising ``click.ClickException`` on any failure.
+
+    ``ClickException`` keeps the helper composable — callers outside the CLI
+    (a future Python API, an MCP tool wrapping diff) get a regular exception
+    instead of the process exiting from inside a library call.
+    """
     if not path.exists():
-        console.print(f"[red]File not found: {path}[/red]")
-        sys.exit(1)
+        raise click.ClickException(f"File not found: {path}")
 
     try:
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
     except json.JSONDecodeError as exc:
-        console.print(f"[red]Invalid JSON in {path}: {exc}[/red]")
-        sys.exit(1)
+        raise click.ClickException(f"Invalid JSON in {path}: {exc}")
     except OSError as exc:
-        console.print(f"[red]Could not read {path}: {exc}[/red]")
-        sys.exit(1)
+        raise click.ClickException(f"Could not read {path}: {exc}")
 
     if not isinstance(data, list):
-        console.print(
-            f"[red]Invalid result file {path}: expected a list of test-case results[/red]"
+        raise click.ClickException(
+            f"Invalid result file {path}: expected a list of test-case results"
         )
-        sys.exit(1)
 
     for index, item in enumerate(data):
         if not isinstance(item, dict):
-            console.print(f"[red]Invalid result file {path}: item {index} is not an object[/red]")
-            sys.exit(1)
-        if not isinstance(item.get("test_case"), str) or not item.get("test_case"):
-            console.print(
-                f"[red]Invalid result file {path}: item {index} is missing test_case[/red]"
+            raise click.ClickException(
+                f"Invalid result file {path}: item {index} is not an object"
             )
-            sys.exit(1)
+        if not isinstance(item.get("test_case"), str) or not item.get("test_case"):
+            raise click.ClickException(
+                f"Invalid result file {path}: item {index} is missing test_case"
+            )
 
     return data
 
@@ -87,10 +89,16 @@ def _cost(case: Dict[str, Any]) -> Optional[float]:
 
 
 def _latency_ms(case: Dict[str, Any]) -> Optional[float]:
-    total_ms = _nested_number(case, "latency", ("total_ms", "total_latency_ms", "total_latency"))
+    # Canonical field across EvalView results files is `total_latency`, in
+    # milliseconds — set in the adapters via `(end - start).total_seconds() * 1000`
+    # (see e.g. evalview/adapters/openclaw_adapter.py:211). The other ms-named
+    # variants are accepted for forward/backward compatibility with adapters
+    # that may emit a more explicit name in the future.
+    total_ms = _nested_number(case, "latency", ("total_latency", "total_latency_ms", "total_ms"))
     if total_ms is not None:
         return total_ms
 
+    # Some external result formats expose seconds; convert.
     seconds = _nested_number(case, "latency", ("total_seconds", "seconds"))
     if seconds is not None:
         return seconds * 1000
@@ -229,8 +237,6 @@ def _format_latency(row: Dict[str, Any]) -> str:
 
 
 def _render_diff(payload: Dict[str, Any]) -> None:
-    from rich.table import Table
-
     table = Table(header_style="bold cyan")
     table.add_column("Test Case")
     table.add_column("Tool Sequence")
@@ -263,14 +269,14 @@ def _render_diff(payload: Dict[str, Any]) -> None:
 @click.command(name="diff", help="Pretty-print what changed between two result files")
 @click.argument("file1", type=click.Path(exists=False, dir_okay=False, path_type=Path))
 @click.argument("file2", type=click.Path(exists=False, dir_okay=False, path_type=Path))
-@click.option("--json", "as_json", is_flag=True, help="Output machine-readable JSON")
+@click.option("--json", "output_json", is_flag=True, help="Output machine-readable JSON")
 @track_command("diff")
-def diff_cmd(file1: Path, file2: Path, as_json: bool) -> None:
+def diff_cmd(file1: Path, file2: Path, output_json: bool) -> None:
     before = _by_test_case(_load_result_file(file1))
     after = _by_test_case(_load_result_file(file2))
     payload = _compare_cases(before, after)
 
-    if as_json:
+    if output_json:
         click.echo(json.dumps(payload, indent=2))
         return
 

--- a/tests/test_diff_cmd.py
+++ b/tests/test_diff_cmd.py
@@ -17,6 +17,11 @@ def _case(
     cost: float = 0.001,
     latency_ms: float = 100.0,
 ) -> Dict[str, Any]:
+    # Mirror the real EvaluationResult shape: `evaluations.latency.total_latency`
+    # is the canonical field, in milliseconds (set in adapters via
+    # `(end - start).total_seconds() * 1000`). Using the real field name in the
+    # fixture ensures these tests would catch a regression in `_latency_ms`'s
+    # field-name list.
     return {
         "test_case": name,
         "passed": True,
@@ -24,7 +29,7 @@ def _case(
         "evaluations": {
             "sequence_correctness": {"actual_sequence": tools or [], "expected_sequence": []},
             "cost": {"total_cost": cost, "passed": True},
-            "latency": {"total_ms": latency_ms, "passed": True},
+            "latency": {"total_latency": latency_ms, "passed": True},
         },
         "actual_output": output,
     }
@@ -153,3 +158,80 @@ def test_diff_json_object_instead_of_list_exits_1(tmp_path: Path) -> None:
 
     assert result.exit_code == 1
     assert "expected a list" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Branches the original PR's tests didn't exercise: the seconds-based latency
+# fallback, malformed items at the per-item level, and graceful degradation
+# when the entire `evaluations` section is missing.
+# ---------------------------------------------------------------------------
+
+
+def test_diff_latency_total_seconds_fallback_is_converted_to_ms(tmp_path: Path) -> None:
+    # Some external result formats (and older EvalView versions) expose
+    # latency as `total_seconds`. _latency_ms must convert to ms so deltas
+    # are comparable across formats.
+    before = tmp_path / "before.json"
+    after = tmp_path / "after.json"
+    seconds_case = {
+        "test_case": "x",
+        "passed": True,
+        "evaluations": {
+            "sequence_correctness": {"actual_sequence": [], "expected_sequence": []},
+            "cost": {"total_cost": 0.001, "passed": True},
+            "latency": {"total_seconds": 1.5, "passed": True},  # 1500 ms
+        },
+        "actual_output": "hi",
+    }
+    seconds_case_after = {**seconds_case, "evaluations": {**seconds_case["evaluations"]}}
+    seconds_case_after["evaluations"] = {**seconds_case["evaluations"]}
+    seconds_case_after["evaluations"]["latency"] = {"total_seconds": 2.0, "passed": True}
+
+    _write_results(before, [seconds_case])
+    _write_results(after, [seconds_case_after])
+
+    result = CliRunner().invoke(diff_cmd, [str(before), str(after), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    row = payload["compared"][0]
+    assert row["latency_before_ms"] == 1500.0
+    assert row["latency_after_ms"] == 2000.0
+    assert row["latency_delta_ms"] == 500.0
+
+
+def test_diff_missing_evaluations_section_degrades_gracefully(tmp_path: Path) -> None:
+    # A result file that lacks the `evaluations` block entirely (e.g. an
+    # early-failure crash result) must still diff cleanly: the row appears
+    # with n/a for tool sequence / cost / latency, no exception.
+    before = tmp_path / "before.json"
+    after = tmp_path / "after.json"
+    skeleton = {"test_case": "ghost", "passed": False, "actual_output": "x"}
+    _write_results(before, [skeleton])
+    _write_results(after, [skeleton])
+
+    result = CliRunner().invoke(diff_cmd, [str(before), str(after), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    row = payload["compared"][0]
+    assert row["tool_sequence"]["before"] == []
+    assert row["tool_sequence"]["after"] == []
+    assert row["cost_before"] is None
+    assert row["latency_before_ms"] is None
+    assert row["cost_delta"] is None
+    assert row["latency_delta_ms"] is None
+
+
+def test_diff_item_missing_test_case_exits_1(tmp_path: Path) -> None:
+    # _load_result_file iterates per-item to validate `test_case`; this
+    # exercises that loop (vs. the top-level shape checks above).
+    before = tmp_path / "before.json"
+    after = tmp_path / "after.json"
+    _write_results(before, [{"passed": True, "actual_output": "no-name"}])
+    _write_results(after, [])
+
+    result = CliRunner().invoke(diff_cmd, [str(before), str(after)])
+
+    assert result.exit_code == 1
+    assert "missing test_case" in result.output


### PR DESCRIPTION
Six small corrections to the diff command merged in #198. #1 and #2 are real bug-prevention; the rest are convention/coverage hardening.

## Changes

| # | What | Why |
|---|------|-----|
| 1 | Test fixture now uses real `evaluations.latency.total_latency` field instead of made-up `total_ms` | Real EvaluationResult JSON uses `total_latency` (ms, set in adapters via `(end - start).total_seconds() * 1000`). The command worked on real data because `_latency_ms` accepted both names — but the green suite wouldn't have caught a regression in the fallback list. |
| 2 | Reorder `_latency_ms` field-name list with canonical `total_latency` first; add a comment pointing at `openclaw_adapter:211` to lock in the unit assumption | Future readers can verify the ms interpretation without re-deriving it from grep. |
| 3 | `sys.exit(1)` → `click.ClickException` in `_load_result_file` | Keeps the helper composable from a future Python API / MCP tool — currently it would abort the process from inside what looks like a library function. |
| 4 | Hoist `from rich.table import Table` to module-level | Same E402 convention recently applied across the codebase. |
| 5 | Rename `as_json` → `output_json` | Naming consistency with `validate_cmd`, `skill_cmd`, `snapshot_cmd`. The CLI flag stays `--json`. |
| 6 | Add 3 tests: seconds-to-ms latency fallback, missing-`evaluations`-section graceful diff, per-item missing-`test_case` validation | Each path was reachable in production but completely untested. |

## Side note for a separate fix

`evalview/core/observability.py:223` treats `total_latency` as seconds and multiplies by 1000 — that appears to be a 1000x bug there since `total_latency` is in ms per all the adapters. **Out of scope** for this PR but worth filing.

## Verification
- 8 tests in `tests/test_diff_cmd.py` (was 5)
- ruff clean across `evalview/` + `tests/`
- mypy clean across 213 source files
- Full suite: 1513 passing

## Test plan
- [x] `pytest tests/test_diff_cmd.py` — 8 pass locally
- [x] `ruff check` — clean
- [x] `mypy evalview/` — clean
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)