### PR TITLE
fix: clear ruff and mypy errors from PR #202 merge

### DIFF
--- a/evalview/chat.py
+++ b/evalview/chat.py
@@ -10,7 +10,7 @@ import subprocess
 import time
 from collections import Counter
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 from rich.console import Console
 from rich.markdown import Markdown
@@ -663,7 +663,7 @@ async def run_chat(
                         test_filter = parts[1].strip() if len(parts) > 1 else None
 
                         test_dirs = ["tests/test-cases", "tests", "test-cases", ".evalview/tests", "."]
-                        test_files = []
+                        test_files: List[Path] = []
                         for test_dir in test_dirs:
                             if Path(test_dir).exists():
                                 test_files.extend(Path(test_dir).glob("*.yaml"))

--- a/evalview/commands/check_cmd.py
+++ b/evalview/commands/check_cmd.py
@@ -6,7 +6,7 @@ import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 import click
 
@@ -17,7 +17,6 @@ from evalview.commands.shared import (
     _create_adapter,
     _execute_check_tests,
     _analyze_check_diffs,
-    _parse_fail_statuses,
 )
 from evalview.commands.check_display import (
     _display_check_results,
@@ -39,7 +38,7 @@ from evalview.commands._check_helpers import (
     _all_failures_retry_healed,
     _filter_test_cases_by_tags,
     _format_baseline_timestamp,  # noqa: F401  (re-exported for backward compat)
-    _format_snapshot_timestamp,
+    _format_snapshot_timestamp,  # noqa: F401  (re-exported for backward compat)
     _judge_usage_summary,
     _normalize_requested_tags,  # noqa: F401  (re-exported for backward compat)
     _print_baseline_context,
@@ -51,7 +50,6 @@ from evalview.commands._check_helpers import (
 
 if TYPE_CHECKING:
     from evalview.core.types import EvaluationResult
-    from evalview.core.diff import TraceDiff
 
 
 

--- a/evalview/skills/evaluators/_security_checks.py
+++ b/evalview/skills/evaluators/_security_checks.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import os
 import re
-from typing import List
+from typing import List, Optional, Tuple
 
 from evalview.skills.agent_types import DeterministicCheckResult
 from evalview.skills.evaluators._security_patterns import (

--- a/evalview/skills/evaluators/deterministic.py
+++ b/evalview/skills/evaluators/deterministic.py
@@ -19,11 +19,10 @@ Each check returns a DeterministicCheckResult with:
 """
 
 import os
-import re
 import signal
 import subprocess
 import logging
-from typing import List, Optional, Set, Tuple
+from typing import List, Optional, Set
 
 from evalview.skills.agent_types import (
     DeterministicExpected,

--- a/evalview/visualization/generators.py
+++ b/evalview/visualization/generators.py
@@ -31,12 +31,13 @@ if TYPE_CHECKING:
     )
 
 
-# Mermaid helpers live in _mermaid.py.
+# Submodule extractions: Mermaid helpers and the HTML/Jinja2 template.
 from evalview.visualization._mermaid import (
     _mermaid_from_steps,
     _mermaid_trace,
     _strip_markdown,
 )
+from evalview.visualization._template import _TEMPLATE
 
 # ── KPI helpers ────────────────────────────────────────────────────────────────
 
@@ -890,7 +891,3 @@ def _render_template(**ctx: Any) -> str:
             d["actual_diagram"] = Markup(d["actual_diagram"])
 
     return env.from_string(_TEMPLATE).render(**ctx)
-
-
-# The HTML/Jinja2 template lives in _template.py.
-from evalview.visualization._template import _TEMPLATE


### PR DESCRIPTION
## Summary

Fixes the 9 ruff errors and 1 mypy error CI flagged after #202 merged. All are import-hygiene fallout from the refactor — names that were used only by helpers now living in submodules, plus two missing typing imports in the new files.

| File | Fix |
|---|---|
| `commands/check_cmd.py` | drop unused `_parse_fail_statuses`, `Tuple`; mark `_format_snapshot_timestamp` as noqa re-export |
| `skills/evaluators/_security_checks.py` | add `Tuple` and `Optional` to typing imports |
| `skills/evaluators/deterministic.py` | drop unused `re` and `Tuple` |
| `visualization/generators.py` | move `_TEMPLATE` import to top of file (E402) |
| `chat.py` | annotate `test_files: List[Path]` for mypy |

Zero functional change. 1792 tests still pass. `ruff check evalview/` and `mypy evalview/` both clean locally.

## Test plan

- [ ] CI passes `Lint & Type Check`
- [ ] CI still passes Test Python 3.9 / 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)