### PR TITLE
Make test suite hermetic: auto-skip LLM tests, fix git signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Lint-clean main** — drop unused `asyncio` and `sys` imports left over
   in `init_cmd.py` after the quickstart removal, which broke the
   `Lint & Type Check` job on `main`.
+- **Hermetic test suite** — `git clone && make test` now goes green on
+  first run with no environment setup beyond `uv`. Specifically:
+    - New `requires_api_key` pytest marker that auto-skips
+      LLM-provider-bound tests when no `OPENAI_API_KEY` /
+      `ANTHROPIC_API_KEY` is set, with a clear skip reason.
+    - `test_current_git_sha_in_a_fresh_git_repo` now passes
+      `commit.gpgsign=false` inline so it works in environments that
+      enforce signing globally.
+    - `test_dogfood_e2e.py` mock-agent fixture skips with a helpful
+      message ("install dev extras: `uv sync --all-extras`") instead of
+      erroring when `fastapi`/`uvicorn` aren't installed.
+    - `make test` now runs `uv sync --all-extras` first so dev deps
+      are guaranteed present before pytest.
 
 ## [0.7.0] - 2026-04-23
 

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ check: format lint typecheck
 
 test:
 	@echo "Running tests with pytest..."
+	@uv sync --all-extras --quiet
 	uv run pytest tests/ -v
 
 test-cov:

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,6 +32,7 @@ markers =
     slow: Tests that take a long time to run
     network: Tests that require network access
     asyncio: Async tests using pytest-asyncio
+    requires_api_key: Tests that need a real LLM provider API key (auto-skipped when no key is set)
 
 # Minimum Python version
 minversion = 7.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,24 +1,49 @@
 """Pytest configuration and shared fixtures for EvalView tests."""
 
 import json
+import os
 from datetime import datetime
-from typing import Dict, Any
 from pathlib import Path
-import pytest
+from typing import Any, Dict
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from evalview.core.types import (
-    TestCase as TestCaseModel,
-    TestInput as TestInputModel,
+    ExecutionMetrics,
+    ExecutionTrace,
     ExpectedBehavior,
     ExpectedOutput,
-    Thresholds,
-    ExecutionTrace,
-    StepTrace,
     StepMetrics,
-    ExecutionMetrics,
+    StepTrace,
+    TestCase as TestCaseModel,
+    TestInput as TestInputModel,
+    Thresholds,
     TokenUsage,
 )
+
+
+# ----------------------------------------------------------------------------
+# requires_api_key marker — auto-skip tests that need a real LLM provider key
+# unless one is set.
+# ----------------------------------------------------------------------------
+
+_API_KEY_ENV_VARS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY")
+
+
+def _has_api_key() -> bool:
+    return any(os.environ.get(v) for v in _API_KEY_ENV_VARS)
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    if _has_api_key():
+        return
+    skip_marker = pytest.mark.skip(
+        reason="requires_api_key: set OPENAI_API_KEY or ANTHROPIC_API_KEY to run"
+    )
+    for item in items:
+        if "requires_api_key" in item.keywords:
+            item.add_marker(skip_marker)
 
 
 # ============================================================================

--- a/tests/test_dogfood_e2e.py
+++ b/tests/test_dogfood_e2e.py
@@ -84,6 +84,11 @@ def mock_agent() -> Generator[Tuple[subprocess.Popen, int], None, None]:
         stderr_text = stderr.decode()
         if "operation not permitted" in stderr_text.lower():
             pytest.skip("Socket binding is not permitted in this environment")
+        if "modulenotfounderror" in stderr_text.lower() or "no module named" in stderr_text.lower():
+            pytest.skip(
+                "Mock agent dependency missing — install dev extras: "
+                "`uv sync --all-extras` (or `make dev-install`)"
+            )
         raise RuntimeError(f"Mock agent failed to start. stderr: {stderr_text}")
 
     yield proc, port

--- a/tests/test_evaluator_accuracy.py
+++ b/tests/test_evaluator_accuracy.py
@@ -5,7 +5,6 @@ for known-good and known-bad agent outputs. This is real dogfooding -
 testing the core evaluation logic, not just the chat interface.
 """
 
-import os
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -391,7 +390,7 @@ class TestOutputContainsAccuracy:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+@pytest.mark.requires_api_key
 class TestOutputEvaluatorLLMAccuracy:
     """Test LLM-as-judge scoring with obvious good/bad responses.
 
@@ -459,7 +458,7 @@ class TestOutputEvaluatorLLMAccuracy:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+@pytest.mark.requires_api_key
 class TestHallucinationEvaluatorAccuracy:
     """Test hallucination detection with obvious true/false cases."""
 

--- a/tests/test_week1_integration.py
+++ b/tests/test_week1_integration.py
@@ -40,7 +40,10 @@ def test_current_git_sha_in_a_fresh_git_repo(tmp_path: Path) -> None:
     """A real git repo should yield a non-empty short SHA."""
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
     subprocess.run(
-        ["git", "-c", "user.email=t@e.com", "-c", "user.name=t",
+        ["git",
+         "-c", "user.email=t@e.com",
+         "-c", "user.name=t",
+         "-c", "commit.gpgsign=false",
          "commit", "-q", "--allow-empty", "-m", "init"],
         cwd=tmp_path,
         check=True,


### PR DESCRIPTION
## Description

This PR makes the test suite hermetic—`git clone && make test` now passes on first run with no environment setup beyond `uv`. The changes ensure tests gracefully skip when external dependencies or API keys are unavailable, rather than failing.

## Type of Change

- [x] Test improvements
- [x] CI/CD improvements
- [x] Code refactoring

## Changes Made

### Test Infrastructure
- **New `requires_api_key` pytest marker** in `conftest.py`:
  - Auto-skips tests that require `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` when neither is set
  - Provides clear skip reason to users
  - Replaces manual `skipif` decorators in test files

- **Updated test markers** in `test_evaluator_accuracy.py`:
  - Replaced `@pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), ...)` with `@pytest.mark.requires_api_key`
  - Removed now-unused `os` import

- **Graceful dependency handling** in `test_dogfood_e2e.py`:
  - Mock agent fixture now skips with helpful message when `fastapi`/`uvicorn` aren't installed
  - Detects "modulenotfounderror" / "no module named" in stderr and suggests `uv sync --all-extras`

- **Git signing fix** in `test_week1_integration.py`:
  - Added `-c commit.gpgsign=false` to git commit in `test_current_git_sha_in_a_fresh_git_repo`
  - Allows test to pass in environments that enforce GPG signing globally

### Build & Configuration
- **Makefile**: `make test` now runs `uv sync --all-extras --quiet` before pytest to ensure dev dependencies are present
- **pytest.ini**: Added `requires_api_key` marker documentation
- **conftest.py**: Reorganized imports (alphabetical, grouped by type) and added helper functions for API key detection

### Documentation
- **CHANGELOG.md**: Documented the hermetic test suite improvements with clear rationale

## Testing

The changes are covered by:
- Existing pytest tests that now use the new `requires_api_key` marker
- CI will verify that `make test` passes without API keys set
- Manual verification: `git clone && make test` should pass without environment setup

All existing tests pass locally with these changes. The new marker is backward-compatible—tests without it run normally.

## Checklist

### Code Quality
- [x] Code follows project style guidelines
- [x] Imports organized and cleaned up
- [x] Self-reviewed for correctness

### Documentation
- [x] CHANGELOG.md updated with feature description
- [x] pytest.ini marker documented

### Testing
- [x] Existing tests pass with new marker
- [x] New skip logic tested implicitly by CI
- [x] No new test dependencies added

### Dependencies
- [x] No new dependencies added
- [x] Uses only existing test infrastructure (pytest, unittest.mock)

## Additional Notes

This change improves the developer experience by eliminating spurious test failures when running the test suite in fresh environments or CI systems without API keys configured. The `requires_api_key` marker is self-documenting and makes test requirements explicit.

https://claude.ai/code/session_01USieLEhX33e3Ejb3mbmpuY