### PR TITLE
chore(importers): tighten parse_csv warn callable type

### DIFF
--- a/evalview/importers/log_importer.py
+++ b/evalview/importers/log_importer.py
@@ -21,7 +21,7 @@ import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 
 # ── Data model ─────────────────────────────────────────────────────────────────
@@ -248,7 +248,7 @@ def parse_csv(
     path: Path,
     max_entries: int = 200,
     *,
-    warn: Any = None,
+    warn: Optional[Callable[[str], None]] = None,
 ) -> List[LogEntry]:
     """Parse a CSV log file.
 


### PR DESCRIPTION
## Summary
- Replaces `warn: Any = None` with `Optional[Callable[[str], None]] = None` in `parse_csv` so the contract is explicit and mypy can catch misuse at the call site.
- Drops `Any` from the public surface for this parameter; behavior unchanged.

## Test plan
- [x] `uv run ruff check evalview/importers/log_importer.py`
- [x] `uv run mypy evalview/importers/log_importer.py --strict` (no new errors)
- [x] `uv run pytest tests/test_log_importer_csv.py -v` — 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)