### PR TITLE
chore(release): 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-05-02
+
+### Added
+- **TOML test cases** — `TestCaseLoader` now understands `.toml` alongside
+  `.yaml`/`.yml` (#209). Same schema, different on-disk encoding for teams
+  that already author config in TOML (`pyproject.toml`-style). Uses stdlib
+  `tomllib` on Python 3.11+ and falls back to `tomli` on 3.9/3.10. Example
+  in `examples/test_case_toml.toml`.
+- **CSV log import** — `evalview generate --from-log` now accepts CSV
+  alongside JSONL, OpenAI, and EvalView capture formats (#216). Header row
+  identifies columns, with aliases matching the JSONL parser
+  (`query`/`input`/`prompt`/...). Tool cells accept JSON list,
+  comma-, semicolon-, or pipe-separated forms. Example fixture and README
+  under `examples/log-import/`.
+
 ### Removed
 - **`evalview quickstart`** — the deprecated compatibility shim has been
   removed. Use `evalview demo` to see a regression caught in 30 seconds, or
@@ -35,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   filing a new "🐕 Dogfood failed" issue every day a check fails. The issue
   auto-closes when dogfood goes green again. Existing per-day failure issues
   were closed as superseded.
+- **Public type for `parse_csv`'s `warn` callback** is now
+  `Optional[Callable[[str], None]]` instead of `Any` (#221), so misuse is
+  caught at the call site by mypy.
 
 ### Docs
 - **`docs/README.md` index expanded** — added entries for `RATIONALE.md`,
@@ -44,6 +62,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`demo/`, `demo-agent/`, and `demo-tests/` each got a README** that
   explains the directory's role and cross-links the other two so the
   three "demo" prefixes don't read as fragmented.
+- **`AGENT_INSTRUCTIONS.md` → `AGENTS.md`** rename (#219), and the
+  `guides/` directory moved under `docs/` so it's colocated with the rest
+  of the docs index. All internal references updated.
+
+### Internal
+- **Four 1k+ files split** into focused submodules following the PR #202
+  pattern (#215): `evalview/test_generation.py` (1638 → 1090),
+  `evalview/reporters/html_reporter.py` (1580 → 636),
+  `evalview/reporters/console_reporter.py` (1303 → 842), and
+  `evalview/commands/run/_cmd.py` (1160 → 837). Mixin classes use
+  `TYPE_CHECKING`-only `_ParentProtocol` forward declarations so cross-mixin
+  attribute access type-checks under `mypy --strict`. Behavior unchanged.
+- **Root-directory polish pass** (#218): `.DS_Store` ignored recursively,
+  `.aider*` glob added, heavy media patterns ignored, stale references
+  (`install.sh` → `scripts/install.sh`) corrected. 39 tracked root entries
+  after the pass.
 
 ### Fixed
 - **Lint-clean main** — drop unused `asyncio` and `sys` imports left over

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evalview",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Open-source testing and regression detection framework for AI agents. Golden baseline diffing, CI/CD integration, works with LangGraph, CrewAI, OpenAI, Claude, HuggingFace, Ollama, and MCP.",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "evalview"
-version = "0.7.0"
+version = "0.7.1"
 description = "Open-source testing and regression detection framework for AI agents. Golden baseline diffing, CI/CD integration, works with LangGraph, CrewAI, OpenAI, Anthropic Claude, HuggingFace, Ollama, and MCP."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` + `package.json` to **0.7.1**
- Rolls the prior `[Unreleased]` polish into a dated `[0.7.1] - 2026-05-02` section, together with the new shipping items:
  - **Added**: TOML test cases (#209), CSV log import for `evalview generate --from-log` (#216)
  - **Changed**: `parse_csv` warn callback type tightened from `Any` → `Optional[Callable[[str], None]]` (#221)
  - **Internal**: four 1k+ files split into focused submodules (#215), root polish pass (#218)
  - **Docs**: `AGENT_INSTRUCTIONS.md` → `AGENTS.md` and `guides/` moved under `docs/` (#219)

## Release plan
After merge:
1. Tag `v0.7.1` and push
2. Publish GitHub release for `v0.7.1` → triggers `.github/workflows/publish.yml` → PyPI auto-publish
3. `npm publish` (no workflow exists for npm; manual step)

## Test plan
- [x] `pyproject.toml` and `package.json` versions match (0.7.1)
- [x] CHANGELOG section dated 2026-05-02 with all merged items since 0.7.0 represented
- [x] No content lost from the prior `[Unreleased]` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)