### PR TITLE
feat(monitor): add --schedule cron syntax to evalview monitor

### DIFF
--- a/evalview/commands/monitor_cmd.py
+++ b/evalview/commands/monitor_cmd.py
@@ -72,6 +72,33 @@ def _append_history(history_path: Path, record: dict) -> None:
         f.write(json.dumps(record) + "\n")
 
 
+def _normalize_scheduled_run(next_run: datetime) -> datetime:
+    """Ensure croniter datetimes can be compared with UTC-aware now."""
+    if next_run.tzinfo is None:
+        return next_run.replace(tzinfo=timezone.utc)
+    return next_run
+
+
+def _format_scheduled_run(next_run: datetime) -> str:
+    return _normalize_scheduled_run(next_run).isoformat()
+
+
+def _seconds_until_scheduled_run(next_run: datetime) -> int:
+    delta = _normalize_scheduled_run(next_run) - datetime.now(timezone.utc)
+    return max(1, int(delta.total_seconds()))
+
+
+def _resolve_wait_seconds(
+    interval: int,
+    cron_iter: Optional[Any],
+) -> Tuple[int, Optional[datetime]]:
+    if cron_iter is None:
+        return interval, None
+
+    next_run = _normalize_scheduled_run(cron_iter.get_next(datetime))
+    return _seconds_until_scheduled_run(next_run), next_run
+
+
 # Default path for the incidents feed that `evalview autopr` consumes. The
 # monitor loop appends one record per confirmed production regression so the
 # autopr command can later convert it into a pinned regression test.
@@ -245,6 +272,8 @@ def _run_monitor_loop(
     cost_threshold: Optional[float] = None,
     latency_threshold: Optional[float] = None,
     incidents_path: Optional[Path] = None,
+    cron_iter: Optional[Any] = None,
+    cadence_label: Optional[str] = None,
 ) -> None:
     """Main monitor loop. Runs check cycles until Ctrl+C.
 
@@ -294,8 +323,9 @@ def _run_monitor_loop(
     strict_hint = (
         f"  |  Strict: {len(strict_tests)}" if strict_tests else ""
     )
+    cadence_label = cadence_label or f"Interval: {interval}s"
     console.print(
-        f"[dim]  Tests: {len(test_cases)}  |  Interval: {interval}s  |  "
+        f"[dim]  Tests: {len(test_cases)}  |  {cadence_label}  |  "
         f"Alerts: {alert_targets}{strict_hint}{history_hint}[/dim]"
     )
     console.print("[dim]  Press Ctrl+C to stop.[/dim]\n")
@@ -333,7 +363,8 @@ def _run_monitor_loop(
                 )
             except Exception as e:
                 console.print(f"[red]  x Cycle {cycle_count} failed: {e}[/red]")
-                _sleep_interruptible(interval, lambda: shutdown)
+                wait_seconds, _ = _resolve_wait_seconds(interval, cron_iter)
+                _sleep_interruptible(wait_seconds, lambda: shutdown)
                 continue
 
             cycle_cost = sum(r.trace.metrics.total_cost for r in results)
@@ -481,7 +512,8 @@ def _run_monitor_loop(
                 _append_history(history_path, record)
 
             previously_failing = currently_failing
-            _sleep_interruptible(interval, lambda: shutdown)
+            wait_seconds, _ = _resolve_wait_seconds(interval, cron_iter)
+            _sleep_interruptible(wait_seconds, lambda: shutdown)
     finally:
         signal.signal(signal.SIGINT, original_sigint)
 
@@ -506,6 +538,7 @@ def _run_monitor_dashboard(
     cost_threshold: Optional[float] = None,
     latency_threshold: Optional[float] = None,
     incidents_path: Optional[Path] = None,
+    cron_iter: Optional[Any] = None,
 ) -> None:
     """Monitor loop with a live-updating Rich dashboard."""
     from rich.live import Live
@@ -648,7 +681,15 @@ def _run_monitor_dashboard(
                 error_msg = str(e)[:60]
                 checking = False
                 live.update(_build_dashboard())
-                _sleep_interruptible(interval, lambda: shutdown)
+                wait_seconds, next_run = _resolve_wait_seconds(interval, cron_iter)
+                if next_run is not None:
+                    next_check_time = _format_scheduled_run(next_run)
+                else:
+                    next_time = datetime.now(timezone.utc).timestamp() + wait_seconds
+                    next_check_time = datetime.fromtimestamp(
+                        next_time, tz=timezone.utc
+                    ).strftime("%H:%M:%S UTC")
+                _sleep_interruptible(wait_seconds, lambda: shutdown)
                 continue
 
             checking = False
@@ -724,10 +765,16 @@ def _run_monitor_dashboard(
                 _append_history(history_path, record)
 
             previously_failing = currently_failing
-            next_time = datetime.now(timezone.utc).timestamp() + interval
-            next_check_time = datetime.fromtimestamp(next_time, tz=timezone.utc).strftime("%H:%M:%S UTC")
+            wait_seconds, next_run = _resolve_wait_seconds(interval, cron_iter)
+            if next_run is not None:
+                next_check_time = _format_scheduled_run(next_run)
+            else:
+                next_time = datetime.now(timezone.utc).timestamp() + wait_seconds
+                next_check_time = datetime.fromtimestamp(
+                    next_time, tz=timezone.utc
+                ).strftime("%H:%M:%S UTC")
             live.update(_build_dashboard())
-            _sleep_interruptible(interval, lambda: shutdown)
+            _sleep_interruptible(wait_seconds, lambda: shutdown)
 
     signal.signal(signal.SIGINT, original_sigint)
     console.print(f"\n[cyan]Monitor stopped after {cycle_count} cycle(s).[/cyan]")
@@ -747,6 +794,14 @@ def _sleep_interruptible(seconds: int, should_stop: Any) -> None:
 @click.command("monitor")
 @click.argument("test_path", default="tests", type=click.Path(exists=True))
 @click.option("--interval", "-i", type=int, default=None, help="Seconds between checks (default: 300)")
+@click.option(
+    "--schedule",
+    default=None,
+    help=(
+        "Cron expression for check cadence (mutually exclusive with --interval). "
+        "Example: '*/5 * * * *' for every 5 minutes."
+    ),
+)
 @click.option("--slack-webhook", default=None, help="Slack webhook URL for alerts")
 @click.option("--discord-webhook", default=None, help="Discord webhook URL for alerts")
 @click.option("--fail-on", default=None, help="Comma-separated statuses that trigger alerts (default: REGRESSION)")
@@ -787,6 +842,7 @@ def _sleep_interruptible(seconds: int, should_stop: Any) -> None:
 def monitor(
     test_path: str,
     interval: Optional[int],
+    schedule: Optional[str],
     slack_webhook: Optional[str],
     discord_webhook: Optional[str],
     fail_on: Optional[str],
@@ -808,6 +864,7 @@ def monitor(
     Examples:
         evalview monitor                                # Check every 5 min
         evalview monitor --interval 60                  # Check every minute
+        evalview monitor --schedule "*/5 * * * *"       # Check on a cron schedule
         evalview monitor --slack-webhook https://...    # Alert to Slack
         evalview monitor --discord-webhook https://...  # Alert to Discord
         evalview monitor --test "weather-lookup"        # Monitor one test
@@ -821,6 +878,7 @@ def monitor(
     Configuration (config.yaml):
         monitor:
           interval: 300
+          schedule: "*/5 * * * *"
           slack_webhook: https://hooks.slack.com/services/...
           discord_webhook: https://discord.com/api/webhooks/...
           fail_on: [REGRESSION]
@@ -839,12 +897,44 @@ def monitor(
     monitor_cfg = config.get_monitor_config() if config else None
 
     resolved_interval = interval or (monitor_cfg.interval if monitor_cfg else 300)
+    # CLI --interval beats a config-only schedule; CLI --schedule + CLI --interval is an error.
+    if schedule is not None and interval is not None:
+        click.echo("Error: --schedule and --interval are mutually exclusive.", err=True)
+        sys.exit(2)
+    if schedule is not None:
+        effective_schedule = schedule
+    elif interval is not None:
+        effective_schedule = None
+    else:
+        effective_schedule = monitor_cfg.schedule if monitor_cfg else None
     resolved_fail_on = fail_on or (",".join(monitor_cfg.fail_on) if monitor_cfg else "REGRESSION")
     resolved_timeout = timeout or (monitor_cfg.timeout if monitor_cfg else 30.0)
 
     if resolved_interval < 10:
         click.echo("Error: --interval must be at least 10 seconds.", err=True)
         sys.exit(1)
+
+    cron_iter = None
+    cadence_label = f"Interval: {resolved_interval}s"
+
+    if effective_schedule:
+        try:
+            from croniter import croniter as _croniter
+        except ImportError:
+            click.echo(
+                "Error: --schedule requires the 'croniter' package. "
+                "Install with: pip install croniter",
+                err=True,
+            )
+            sys.exit(2)
+        try:
+            now = datetime.now(timezone.utc)
+            cron_iter = _croniter(effective_schedule, now)
+            next_run = _croniter(effective_schedule, now).get_next(datetime)
+            cadence_label = f"Next run: {_format_scheduled_run(next_run)}"
+        except Exception as e:
+            click.echo(f"Error: invalid cron expression {effective_schedule!r}: {e}", err=True)
+            sys.exit(2)
 
     if resolved_timeout <= 0:
         click.echo("Error: --timeout must be a positive number.", err=True)
@@ -891,6 +981,7 @@ def monitor(
                 cost_threshold=resolved_cost_threshold,
                 latency_threshold=resolved_latency_threshold,
                 incidents_path=resolved_incidents,
+                cron_iter=cron_iter,
             )
         else:
             _run_monitor_loop(
@@ -906,6 +997,8 @@ def monitor(
                 cost_threshold=resolved_cost_threshold,
                 latency_threshold=resolved_latency_threshold,
                 incidents_path=resolved_incidents,
+                cron_iter=cron_iter,
+                cadence_label=cadence_label,
             )
     except MonitorError as e:
         console.print(f"[red]ERROR {e}[/red]")

--- a/evalview/commands/monitor_cmd.py
+++ b/evalview/commands/monitor_cmd.py
@@ -919,7 +919,7 @@ def monitor(
 
     if effective_schedule:
         try:
-            from croniter import croniter as _croniter
+            from croniter import croniter as _croniter  # type: ignore[import-untyped]
         except ImportError:
             click.echo(
                 "Error: --schedule requires the 'croniter' package. "

--- a/evalview/core/config.py
+++ b/evalview/core/config.py
@@ -173,6 +173,13 @@ class MonitorConfig(BaseModel):
         ge=10,
         description="Seconds between check cycles"
     )
+    schedule: Optional[str] = Field(
+        default=None,
+        description=(
+            "Cron expression for monitor cycles (alternative to interval). "
+            "Mutually exclusive with interval. Requires the optional croniter dependency."
+        ),
+    )
     slack_webhook: Optional[str] = Field(
         default=None,
         description="Slack incoming webhook URL for regression alerts"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ reports = [
 watch = [
     "watchdog>=3.0",
 ]
+# Cron schedule support for monitor mode
+schedule = [
+    "croniter>=2.0",
+]
 # Telemetry (opt-out anonymous usage analytics)
 telemetry = [
     "posthog>=3.0.0",
@@ -73,6 +77,7 @@ mistral = [
 all = [
     "plotly>=5.0",
     "watchdog>=3.0",
+    "croniter>=2.0",
     "posthog>=3.0.0",
     "cohere>=5.0.0",
     "mistralai>=1.0.0",

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -2,11 +2,15 @@
 
 import asyncio
 import json
+import sys
+import types
 from datetime import datetime
+from datetime import timedelta
 from pathlib import Path
 from typing import Set
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from click.testing import CliRunner
 import pytest
 import yaml
 
@@ -17,6 +21,7 @@ from evalview.commands.monitor_cmd import (
     _resolve_slack_webhook,
     _run_monitor_loop,
     _sleep_interruptible,
+    monitor,
 )
 from evalview.core.discord_notifier import DiscordNotifier
 from evalview.core.diff import DiffStatus
@@ -480,6 +485,119 @@ class TestDiscordNotifier:
 # MonitorConfig
 # ---------------------------------------------------------------------------
 
+class FakeCroniter:
+    """Minimal croniter stand-in for CLI tests when the optional dep is absent."""
+
+    def __init__(self, expression, start_time):
+        if expression == "not a cron":
+            raise ValueError("bad cron")
+        self.expression = expression
+        self.start_time = start_time
+
+    def get_next(self, return_type):
+        return self.start_time + timedelta(minutes=5)
+
+
+def _install_fake_croniter(monkeypatch):
+    module = types.ModuleType("croniter")
+    module.croniter = FakeCroniter
+    monkeypatch.setitem(sys.modules, "croniter", module)
+
+
+class TestMonitorScheduleCLI:
+    """Test cron schedule command-line behavior."""
+
+    def test_schedule_and_interval_mutually_exclusive(self):
+        result = CliRunner().invoke(
+            monitor,
+            ["tests", "--interval", "60", "--schedule", "*/5 * * * *"],
+        )
+
+        assert result.exit_code == 2
+        assert "--schedule and --interval are mutually exclusive" in result.output
+
+    def test_invalid_cron_expression_errors(self, monkeypatch):
+        _install_fake_croniter(monkeypatch)
+
+        result = CliRunner().invoke(
+            monitor,
+            ["tests", "--schedule", "not a cron"],
+        )
+
+        assert result.exit_code == 2
+        assert "invalid cron expression" in result.output
+        assert "not a cron" in result.output
+
+    def test_valid_cron_expression_parses(self, monkeypatch):
+        _install_fake_croniter(monkeypatch)
+        captured = {}
+
+        def fake_run_monitor_loop(**kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setattr(
+            "evalview.commands.monitor_cmd._load_config_if_exists",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            "evalview.commands.monitor_cmd._run_monitor_loop",
+            fake_run_monitor_loop,
+        )
+
+        result = CliRunner().invoke(
+            monitor,
+            ["tests", "--schedule", "*/5 * * * *"],
+        )
+
+        assert result.exit_code == 0
+        assert captured["cron_iter"].expression == "*/5 * * * *"
+        assert captured["cadence_label"].startswith("Next run: ")
+
+    def test_status_output_shows_next_scheduled_run(self, capsys):
+        with (
+            patch("evalview.core.golden.GoldenStore") as store_cls,
+            patch("evalview.core.loader.TestCaseLoader") as loader_cls,
+            patch(
+                "evalview.commands.monitor_cmd._execute_check_tests",
+                side_effect=KeyboardInterrupt,
+            ),
+            patch("evalview.commands.monitor_cmd.signal"),
+        ):
+            store_cls.return_value.list_golden.return_value = [object()]
+            loader_cls.return_value.load_from_directory.return_value = [
+                types.SimpleNamespace(name="example", gate=None)
+            ]
+
+            with pytest.raises(KeyboardInterrupt):
+                _run_monitor_loop(
+                    test_path="tests",
+                    interval=300,
+                    slack_webhook=None,
+                    discord_webhook=None,
+                    fail_on="REGRESSION",
+                    timeout=30.0,
+                    test_filter=None,
+                    cadence_label="Next run: 2026-05-03T00:05:00+00:00",
+                )
+
+        assert "Next run: 2026-05-03T00:05:00+00:00" in capsys.readouterr().out
+
+    def test_config_schedule_field(self):
+        from evalview.core.config import EvalViewConfig
+
+        raw = yaml.safe_load(
+            """
+            adapter: http
+            endpoint: http://example.com
+            monitor:
+              schedule: "0 * * * *"
+            """
+        )
+        config = EvalViewConfig(**raw)
+
+        assert config.get_monitor_config().schedule == "0 * * * *"
+
+
 class TestMonitorConfig:
     """Test MonitorConfig defaults and validation."""
 
@@ -491,11 +609,18 @@ class TestMonitorConfig:
         assert cfg.discord_webhook is None
         assert cfg.fail_on == ["REGRESSION"]
         assert cfg.timeout == 30.0
+        assert cfg.schedule is None
 
     def test_custom_values(self):
         from evalview.core.config import MonitorConfig
-        cfg = MonitorConfig(interval=60, timeout=120.0, fail_on=["REGRESSION", "TOOLS_CHANGED"])
+        cfg = MonitorConfig(
+            interval=60,
+            schedule="*/10 * * * *",
+            timeout=120.0,
+            fail_on=["REGRESSION", "TOOLS_CHANGED"],
+        )
         assert cfg.interval == 60
+        assert cfg.schedule == "*/10 * * * *"
         assert cfg.timeout == 120.0
         assert len(cfg.fail_on) == 2
 


### PR DESCRIPTION
Closes #84.

Adds a `--schedule` flag accepting cron syntax as an alternative to `--interval`, matching the implementation guide you wrote in the issue.

```bash
evalview monitor --schedule "*/5 * * * *"   # every 5 min
evalview monitor --schedule "0 9-17 * * 1-5" # business hours weekdays
```

Behavior

- New `--schedule` Click option on `monitor`.
- New `schedule` field on `MonitorConfig` (config.yaml: `monitor.schedule`).
- CLI `--schedule` and CLI `--interval` are mutually exclusive (exits 2). A CLI `--interval` cleanly overrides a config-only schedule, so an ad-hoc one-off run does not require editing the config.
- `croniter` import is lazy. Missing dep raises a friendly `pip install croniter` message instead of a traceback.
- Invalid cron string is caught and reported with the offending expression.
- `_run_monitor_loop` and `_run_monitor_dashboard` both consume an optional `cron_iter` to compute each cycle's wait via `croniter.get_next(datetime)`. Naive datetimes from croniter are normalized to UTC so the subtraction against `datetime.now(timezone.utc)` works.
- The startup status line now shows `Next run: <iso>` when a schedule is active and falls back to `Interval: <seconds>s` otherwise. The dashboard variant surfaces the same.
- `croniter>=2.0` added under the new `schedule` extra in `pyproject.toml` (also rolled into the existing `all` extra).

Tests

- Mutual exclusion (`--interval` + `--schedule`) errors with exit 2.
- Invalid cron expression errors with exit 2 and the bad string in the message.
- Valid cron parses, threads `cron_iter` into `_run_monitor_loop`, and produces a `Next run:` cadence label.
- Status output includes the next scheduled run when `cadence_label` is set.
- New `MonitorConfig.schedule` field default + custom value.

`uv run python -m pytest tests/test_monitor.py -x -q` -> 50/50 pass.

Test runner uses a `FakeCroniter` injected via `monkeypatch` so the suite does not require the optional dep.