### PR TITLE
Add record/replay cassettes for hermetic tool call simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Record/replay cassettes for `evalview simulate`** — capture real
+  tool calls once, replay deterministically forever. Closes the
+  reproducibility gap where reproducing "agent saw X, called Y, got Z"
+  required hitting live services again. Cassettes live at
+  `.evalview/cassettes/<test>.json`, are versioned for forward compat,
+  and use per-tool sequential matching so inter-tool ordering drift
+  doesn't break replay. New flags: `--record`, `--replay`,
+  `--cassette-dir`. Declarative `mocks:` still take precedence so a
+  single recording can be overridden without re-recording the whole
+  run. See `docs/SIMULATE.md#record--replay-cassettes`.
+- **Adapter capability check for simulation** — `Simulator` now
+  detects when an adapter has no tool interception seam (no
+  `tool_executor` attribute, no `install_mock_interceptor`) and
+  fails fast under `--record` / `--replay` / `mocks.strict=true`
+  instead of silently letting the run hit live services. Lenient
+  mode logs a warning unless `--allow-live` is set.
+  `SimulationResult.adapter_capability` records the truth so JSON/CI
+  consumers can see whether interception was actually possible. See
+  `docs/design/loud-skip-warning.md`.
+
 ## [0.7.1] - 2026-05-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Most eval tools stop at detect and compare. EvalView helps you classify changes,
 - Catch silent regressions that normal tests miss
 - Separate provider/model drift from real system regressions
 - Auto-heal flaky failures with retries, review gates, and audit logs
+- Replay deterministically — cassettes capture real tool calls once so CI never re-hits live services
 
 Built for **frontier-lab rigor, startup-team practicality**:
 - targeted behavior runs instead of giant always-on eval suites
@@ -269,6 +270,7 @@ Use LangSmith for observability. Use Braintrust for scoring. **Use EvalView for 
 | Golden baseline regression | — | Manual | — | **Automatic** |
 | Silent model change detection | — | — | — | **Yes** |
 | Auto-heal (retry + variant proposal) | — | — | — | **Yes** |
+| Hermetic record/replay | — | — | — | **Yes** |
 | PR comments with alerts | — | — | — | **Cost, latency, model change** |
 | Works without API keys | No | No | Partial | **Yes** |
 | Production monitoring | Tracing | — | — | **Check loop + Slack** |
@@ -704,6 +706,15 @@ Two features that close the gaps the April 2026 agent-eval reports kept calling 
 evalview simulate tests/ --variants 5 --seed 42
 ```
 
+**Record/replay cassettes** — declarative mocks are tedious for agents with dozens of tools. Record once against the real backend, replay forever — no network, no LLM cost beyond the agent's own model calls, no flaky third-party APIs in CI. *"The agent saw X, called Y, got Z"* becomes deterministic without re-hitting live services.
+
+```bash
+evalview simulate tests/refund.yaml --record    # capture real tool results once
+evalview simulate tests/refund.yaml --replay    # hermetic from now on
+```
+
+Cassettes live at `.evalview/cassettes/<test>.json`, use per-tool sequential matching (robust to inter-tool ordering drift), and are versioned for forward compatibility. Declarative `mocks:` still take precedence so you can override a single recording without re-recording the whole run.
+
 **Decision rationale** — every tool_choice / branch gets recorded with the chosen option, alternatives considered, and any model-reported reasoning (Anthropic `thinking` blocks auto-captured). Grouped across runs by `input_hash` so cloud analytics surfaces decision drift before your users notice. Local HTML replay shows it inline.
 
 Supported adapters: Anthropic, OpenAI Assistants, LangGraph, CrewAI native.
@@ -722,6 +733,7 @@ Supported adapters: Anthropic, OpenAI Assistants, LangGraph, CrewAI native.
 | **Recommendation engine** | Suggests the next command from verdict, drift class, and history | [Above](#daily-workflow) |
 | **Model drift detection** | `model-check` — zero-judge canary suite that catches silent model updates | [Docs](#model-drift-detection) |
 | **Simulation harness** | `evalview simulate` — hermetic what-if runs against declared mocks, with `--variants N` fan-out | [Docs](docs/SIMULATE.md) |
+| **Record/replay cassettes** | Capture real tool calls once, replay deterministically forever — no live services in CI | [Docs](docs/SIMULATE.md#record--replay-cassettes) |
 | **Decision rationale** | Structured `tool_choice` / `branch` logging with cross-run grouping for decision-drift detection | [Docs](docs/RATIONALE.md) |
 | **Assertion wizard** | Analyze captured traffic, suggest smart assertions automatically | [Above](#assertion-wizard--tests-from-real-traffic) |
 | **Auto-variant discovery** | Run N times, cluster paths, save valid variants | [Above](#auto-variant-discovery--solve-non-determinism) |

--- a/docs/SIMULATE.md
+++ b/docs/SIMULATE.md
@@ -192,15 +192,71 @@ Aggregate output:
 ```
 evalview simulate [TEST_PATH] [OPTIONS]
 
-TEST_PATH      Directory (default: tests/) or single YAML file.
+TEST_PATH        Directory (default: tests/) or single YAML file.
 
--t, --test     Run only this test by name.
-    --seed     Override the seed declared in YAML.
-    --variants Run N deterministic replays (default: 1).
-    --json     Emit JSON summary for CI.
+-t, --test       Run only this test by name.
+    --seed       Override the seed declared in YAML.
+    --variants   Run N deterministic replays (default: 1).
+    --json       Emit JSON summary for CI.
+    --record     Capture every real tool call into a cassette under
+                 .evalview/cassettes/<test>.json.
+    --replay     Serve tool calls from the cassette at the same path
+                 (hermetic — never touches the network).
+    --cassette-dir DIR
+                 Override the cassette directory (default: .evalview/cassettes).
 ```
 
 Exit code 1 on any test error; 0 on success.
+
+## Record / replay cassettes
+
+Declarative `mocks:` are great when you know exactly what each tool
+should return, but they're tedious for agents with dozens of tools or
+variable params. Cassettes solve that — record once against the real
+backend, replay forever:
+
+```bash
+# 1. Once, against a live backend (or a staging fixture):
+evalview simulate tests/refund.yaml --record
+
+# 2. Forever after, hermetically — no network, no LLM cost beyond the
+#    agent's own model calls (which can be mocked separately):
+evalview simulate tests/refund.yaml --replay
+```
+
+Cassettes live at `.evalview/cassettes/<test-name>.json` and look like:
+
+```json
+{
+  "version": 1,
+  "test_name": "refund",
+  "recorded_at": "2026-05-04T12:34:56+00:00",
+  "adapter": "anthropic",
+  "interactions": [
+    {"kind": "tool", "tool": "lookup_order", "params": {"id": 4812}, "returns": {"id": 4812, "total": 99.0}, "error": null},
+    {"kind": "tool", "tool": "process_refund", "params": {"id": 4812}, "returns": {"status": "ok"}, "error": null}
+  ]
+}
+```
+
+**Matching rules.** Per-tool sequential: each tool name has its own
+queue of recordings, consumed in declaration order. The agent can
+legitimately reorder `lookup_order` vs `check_policy` between runs and
+replay still works — only intra-tool sequence matters.
+
+**Precedence.** If both a declarative `mocks:` block and a cassette
+exist, declarative mocks win first (so you can override a single
+recording without re-recording the whole run); cassette serves the
+rest; live executor serves anything still unmatched (unless
+`mocks.strict=true`, in which case unmatched calls raise).
+
+**Recording is transparent.** The recorder runs the real executor
+first, then captures the result. Errors are recorded too and re-raised
+from replay, so the agent sees identical behavior either way.
+
+**Synthetic mocks are not recorded.** Calls that hit a declarative
+`tool_mocks` entry never reach the recorder — the cassette only
+captures what the real layer actually returned.
 
 ## Adapter support matrix
 

--- a/docs/SIMULATE.md
+++ b/docs/SIMULATE.md
@@ -204,9 +204,36 @@ TEST_PATH        Directory (default: tests/) or single YAML file.
                  (hermetic — never touches the network).
     --cassette-dir DIR
                  Override the cassette directory (default: .evalview/cassettes).
+    --allow-live Suppress the warning when the adapter has no
+                 interception seam. Hermetic modes still raise.
 ```
 
 Exit code 1 on any test error; 0 on success.
+
+## Adapter capability check
+
+Before every run, the simulator probes the adapter for three
+interception layers:
+
+| Layer | Detection | Purpose |
+|---|---|---|
+| `tools` | `hasattr(adapter, "tool_executor")` | Tool-call swap (the path mocks/cassettes use). |
+| `responses` | `callable(adapter.install_mock_interceptor)` | LLM-response pull hooks. |
+| `http` | `getattr(adapter, "supports_http_mocks", False)` | Outbound HTTP intercept opt-in. |
+
+The result lands on `SimulationResult.adapter_capability` and renders
+under "Adapter capability:" in the human output.
+
+**When the adapter has none of the three** (e.g. an HTTP/streaming
+adapter where the agent runs server-side), the simulator escalates:
+
+| Run mode | Behavior |
+|---|---|
+| Lenient (no `--record` / `--replay` / `mocks.strict`) | Logs a `WARNING`. Drops to `INFO` with `--allow-live`. |
+| Hermetic (`--record`, `--replay`, or `mocks.strict=true`) | Raises `UninterceptableAdapterError` before any live call. |
+
+This means a `--replay` against an unsupported adapter fails fast
+instead of silently going live with an empty mock layer.
 
 ## Record / replay cassettes
 

--- a/docs/design/loud-skip-warning.md
+++ b/docs/design/loud-skip-warning.md
@@ -1,0 +1,196 @@
+# Design: loud failure when simulation can't actually intercept
+
+**Status:** proposed
+**Author:** EvalView reproducibility track
+**Companion:** [SIMULATE.md](../SIMULATE.md), [`evalview/core/cassette.py`](../../evalview/core/cassette.py)
+
+## Problem
+
+The `Simulator` installs mocks/cassettes by **monkey-patching the
+adapter's `tool_executor` attribute** ([`simulation.py:225`](../../evalview/core/simulation.py)):
+
+```python
+had_attr = hasattr(self._adapter, "tool_executor")
+if had_attr:
+    setattr(self._adapter, "tool_executor", mocked)
+```
+
+When `had_attr` is false — the adapter has no `tool_executor` attribute
+to patch and no `install_mock_interceptor` either — the simulator
+**silently skips installation**. The agent runs against live
+dependencies. There is currently no warning, no error, and no
+indication in the output.
+
+This breaks the "hermetic CI" promise for at least these adapters
+(based on `grep "tool_executor" evalview/adapters/`):
+
+| Adapter | Has `tool_executor`? | Has `install_mock_interceptor`? |
+|---|---|---|
+| anthropic_adapter.py | ✅ | — |
+| openai_assistants_adapter.py | unknown — needs audit | unknown |
+| crewai_native_adapter.py | unknown | unknown |
+| http_adapter.py | ❌ (calls happen server-side) | — |
+| langgraph_adapter.py | likely ❌ for cloud, ✅ for native | — |
+| ollama_adapter.py | unknown | unknown |
+| mcp_adapter.py | unknown | unknown |
+| (others) | unknown | unknown |
+
+A user who runs `evalview simulate --strict` (or `--replay`) against
+an HTTP/streaming adapter will see "Mocks applied: none matched" — the
+same output they'd see if their declarative mocks just didn't match.
+There is no way to tell whether the run was hermetic or live.
+
+## Goal
+
+Make it impossible to run `simulate`/`replay`/`record` against an
+uninterceptable adapter without knowing it.
+
+## Non-goals
+
+- **Don't refuse to run.** Some users explicitly want `simulate` to
+  fan out variants against a partially-live adapter. The signal is
+  what changes; the run still goes.
+- **Don't try to add interception** to remote adapters here. That's a
+  separate, larger effort (e.g. server-side `install_mock_interceptor`,
+  HTTP-transport wrapping). This design only fixes visibility.
+
+## Proposal
+
+### 1. Capability check on the adapter
+
+Add a small helper in `evalview/core/simulation.py`:
+
+```python
+def adapter_simulation_capability(adapter) -> dict:
+    """Report which simulation layers this adapter actually supports.
+
+    Returns a dict with three booleans:
+      tools:     can intercept tool calls (has tool_executor attr)
+      responses: can intercept LLM responses (has install_mock_interceptor)
+      http:      can intercept outbound HTTP (declares supports_http_mocks)
+    """
+    return {
+        "tools": hasattr(adapter, "tool_executor"),
+        "responses": callable(getattr(adapter, "install_mock_interceptor", None)),
+        "http": bool(getattr(adapter, "supports_http_mocks", False)),
+    }
+```
+
+### 2. Three escalation tiers
+
+| Condition | Behavior | Where |
+|---|---|---|
+| Adapter supports tools, mocks declared | silent (today) | unchanged |
+| Adapter supports tools, no mocks declared | DEBUG log | unchanged |
+| Adapter has **none** of the three capabilities, run uses mocks/cassette/replay | **WARN log + stderr banner** | `Simulator.run` / `run_variants` entry |
+| Same as above + `MockSpec.strict=True` OR `--replay` flag set | **raise `UninterceptableAdapterError`** | same |
+
+The warning text:
+
+```
+⚠ Adapter 'http' cannot intercept tool calls — mocks/cassette declared
+  but none will be installed. The run is hitting live services.
+  See docs/SIMULATE.md#adapter-support-matrix.
+```
+
+The strict/replay error is fail-fast at the start of the run, before
+any live call has been made.
+
+### 3. Surface in the JSON / human output
+
+Extend `SimulationResult` (in `types.py`) with one field:
+
+```python
+adapter_capability: Dict[str, bool] = Field(default_factory=dict)
+```
+
+The `simulate` CLI prints it under the "Mocks applied:" section so
+users see the *capability*, not just the absence of matches:
+
+```
+▶ flight-search-sim  (seed=42, variants=1)
+  Mocks applied: none matched
+  Adapter capability: tools=✗ responses=✗ http=✗   ← new line, red when all-false
+  Variants:
+    · #0 branch=b0 $0.0000 0ms
+```
+
+### 4. CLI flag for opt-in to live runs
+
+Add `--allow-live` to `evalview simulate` to suppress the warning when
+the user has consciously decided that a partially-live run is fine.
+Without the flag, the warning fires every run; with it, the warning
+becomes a single-line `INFO`.
+
+## Implementation sketch
+
+Three small changes, all in already-touched files:
+
+1. **`evalview/core/simulation.py`** (~20 lines)
+   - Add `adapter_simulation_capability()` helper.
+   - Add `UninterceptableAdapterError` class.
+   - At the top of `Simulator.run` / `run_variants`, compute
+     capability; if all-false AND mocks/cassette/replay are in play,
+     either warn (lenient) or raise (strict/replay).
+   - Stamp capability into `SimulationResult` for downstream.
+
+2. **`evalview/core/types.py`** (~3 lines)
+   - Add `adapter_capability: Dict[str, bool]` to `SimulationResult`.
+
+3. **`evalview/commands/simulate_cmd.py`** (~10 lines)
+   - Add `--allow-live` flag.
+   - Render the capability line in `_format_human`.
+
+4. **`evalview/adapters/*`** (audit + tag, ~1 line per adapter)
+   - For each adapter, confirm whether `tool_executor` exists; if it
+     doesn't but the adapter could support `install_mock_interceptor`,
+     leave a TODO. (No code change today; just establishes ground
+     truth for the matrix.)
+
+## Tests
+
+- `test_simulation.py::test_warns_when_adapter_uninterceptable` —
+  fake adapter without `tool_executor`; assert WARN logged and
+  stderr banner present.
+- `test_simulation.py::test_raises_under_strict_when_uninterceptable`
+  — same fake adapter, `MockSpec(strict=True)`, assert
+  `UninterceptableAdapterError`.
+- `test_simulation.py::test_raises_when_replay_uninterceptable` —
+  pass a cassette to a non-tool-executor adapter, assert raise.
+- `test_simulation.py::test_allow_live_suppresses_warning` — pass
+  through CLI; assert `--allow-live` downgrades to INFO.
+- `test_simulation.py::test_capability_recorded_in_result` —
+  assert `SimulationResult.adapter_capability` reflects the truth
+  for both an interceptable and uninterceptable adapter.
+
+## Rollout
+
+- One PR, no migration. The warning is purely additive; the strict
+  raise only fires in modes (`strict=True`, `--replay`) where the
+  user has already opted into hermetic semantics — they would *want*
+  to be told the run is silently going live.
+- Update `docs/SIMULATE.md`'s adapter matrix to use the same
+  `tools/responses/http` rubric as the runtime check, so the doc and
+  the CLI never disagree.
+
+## Why not just refuse to run?
+
+Mixed live/mock runs are legitimately useful — e.g. `simulate` against
+a real LLM but with one flaky tool stubbed. The warning is the floor;
+strict mode (which the user opts into) is the ceiling. This matches
+the existing `MockSpec.strict` semantics and avoids breaking any
+working workflow.
+
+## Open questions
+
+1. Should the `record` flag also raise on uninterceptable adapters?
+   It would silently produce an empty cassette today, which is
+   confusing. Recommendation: yes, raise — same as `--replay`.
+2. Should the capability check distinguish "adapter has the attribute
+   but it's `None`" (Anthropic before init) from "adapter doesn't
+   support it"? Probably yes — `hasattr` returns true for both today.
+3. The `supports_http_mocks` flag is new and will be missing from
+   every adapter at first; default `False` is the safe answer but
+   means the HTTP-mock column is "✗" everywhere until adapters
+   explicitly opt in. That's fine — accurate is better than
+   optimistic.

--- a/evalview/commands/simulate_cmd.py
+++ b/evalview/commands/simulate_cmd.py
@@ -87,9 +87,9 @@ def _format_human(
 
     if adapter_capability:
         cap_str = (
-            f"tools={_capability_flag(adapter_capability.get('tools'))} "
-            f"responses={_capability_flag(adapter_capability.get('responses'))} "
-            f"http={_capability_flag(adapter_capability.get('http'))}"
+            f"tools={_capability_flag(bool(adapter_capability.get('tools')))} "
+            f"responses={_capability_flag(bool(adapter_capability.get('responses')))} "
+            f"http={_capability_flag(bool(adapter_capability.get('http')))}"
         )
         if not any(adapter_capability.values()):
             cap_str += "  ⚠ adapter has no interception seam — run is hitting live services"

--- a/evalview/commands/simulate_cmd.py
+++ b/evalview/commands/simulate_cmd.py
@@ -62,6 +62,10 @@ def _resolve_test_cases(
     return cases
 
 
+def _capability_flag(value: bool) -> str:
+    return "✓" if value else "✗"
+
+
 def _format_human(
     test_name: str,
     seed: int,
@@ -69,6 +73,7 @@ def _format_human(
     mocks_applied: List[dict],
     variant_outcomes: List[dict],
     branches: List[dict],
+    adapter_capability: Optional[dict] = None,
 ) -> str:
     """Readable terminal summary. JSON path skips this entirely."""
     lines: List[str] = []
@@ -79,6 +84,16 @@ def _format_human(
             lines.append(f"    · {m['kind']}:{m['matcher']} ×{m['count']}")
     else:
         lines.append("  Mocks applied: none matched")
+
+    if adapter_capability:
+        cap_str = (
+            f"tools={_capability_flag(adapter_capability.get('tools'))} "
+            f"responses={_capability_flag(adapter_capability.get('responses'))} "
+            f"http={_capability_flag(adapter_capability.get('http'))}"
+        )
+        if not any(adapter_capability.values()):
+            cap_str += "  ⚠ adapter has no interception seam — run is hitting live services"
+        lines.append(f"  Adapter capability: {cap_str}")
 
     lines.append("  Variants:")
     if variant_outcomes:
@@ -109,6 +124,7 @@ async def _run_one(
     *,
     record: bool = False,
     replay: bool = False,
+    allow_live: bool = False,
     cassette_dir: Path = DEFAULT_CASSETTE_DIR,
 ) -> dict:
     """Run a single test case and return a serializable summary dict."""
@@ -146,11 +162,18 @@ async def _run_one(
     sim = Simulator(adapter, spec)
     if variants > 1:
         traces, result = await sim.run_variants(
-            tc, variants=variants, replay_cassette=replay_cassette, record=record
+            tc,
+            variants=variants,
+            replay_cassette=replay_cassette,
+            record=record,
+            allow_live=allow_live,
         )
     else:
         _, result = await sim.run(
-            tc, replay_cassette=replay_cassette, record=record
+            tc,
+            replay_cassette=replay_cassette,
+            record=record,
+            allow_live=allow_live,
         )
         traces = []
 
@@ -202,6 +225,17 @@ async def _run_one(
     show_default=True,
     help="Override the directory used to find/store cassettes.",
 )
+@click.option(
+    "--allow-live",
+    is_flag=True,
+    default=False,
+    help=(
+        "Suppress the warning when the adapter has no interception seam. "
+        "By default an uninterceptable adapter logs a warning; with this "
+        "flag it logs INFO instead. Hermetic modes (--record, --replay, "
+        "or mocks.strict=true) still raise."
+    ),
+)
 @track_command("simulate")
 def simulate(
     test_path: str,
@@ -212,6 +246,7 @@ def simulate(
     record: bool,
     replay: bool,
     cassette_dir: str,
+    allow_live: bool,
 ) -> None:
     """Run tests hermetically against declared mocks.
 
@@ -245,7 +280,9 @@ def simulate(
         try:
             summary = asyncio.run(_run_one(
                 tc, config, variants, seed,
-                record=record, replay=replay, cassette_dir=cassette_dir_path,
+                record=record, replay=replay,
+                allow_live=allow_live,
+                cassette_dir=cassette_dir_path,
             ))
         except Exception as exc:
             summaries.append({
@@ -267,6 +304,7 @@ def simulate(
                     sim["mocks_applied"],
                     sim["variant_outcomes"],
                     sim["branches_explored"],
+                    adapter_capability=sim.get("adapter_capability"),
                 )
             )
             if summary.get("cassette"):

--- a/evalview/commands/simulate_cmd.py
+++ b/evalview/commands/simulate_cmd.py
@@ -24,6 +24,12 @@ from typing import List, Optional
 import click
 
 from evalview.core.adapter_factory import create_adapter_from_config
+from evalview.core.cassette import (
+    DEFAULT_CASSETTE_DIR,
+    cassette_path_for,
+    load_cassette,
+    save_cassette,
+)
 from evalview.core.config import EvalViewConfig
 from evalview.core.loader import TestCaseLoader
 from evalview.core.simulation import Simulator
@@ -100,6 +106,10 @@ async def _run_one(
     config: Optional[EvalViewConfig],
     variants: int,
     seed_override: Optional[int],
+    *,
+    record: bool = False,
+    replay: bool = False,
+    cassette_dir: Path = DEFAULT_CASSETTE_DIR,
 ) -> dict:
     """Run a single test case and return a serializable summary dict."""
     if tc.mocks is None:
@@ -123,18 +133,47 @@ async def _run_one(
     )
     adapter = create_adapter_from_config(run_config)
 
+    cassette_path = cassette_path_for(tc.name, cassette_dir)
+    replay_cassette = None
+    if replay:
+        if not cassette_path.exists():
+            raise click.ClickException(
+                f"--replay set but no cassette found at {cassette_path}. "
+                f"Run with --record first."
+            )
+        replay_cassette = load_cassette(cassette_path)
+
     sim = Simulator(adapter, spec)
     if variants > 1:
-        traces, result = await sim.run_variants(tc, variants=variants)
+        traces, result = await sim.run_variants(
+            tc, variants=variants, replay_cassette=replay_cassette, record=record
+        )
     else:
-        _, result = await sim.run(tc)
+        _, result = await sim.run(
+            tc, replay_cassette=replay_cassette, record=record
+        )
         traces = []
+
+    cassette_info: Optional[dict] = None
+    if record and result.recorded_cassette is not None:
+        save_cassette(result.recorded_cassette, cassette_path)
+        cassette_info = {
+            "path": str(cassette_path),
+            "interactions": len(result.recorded_cassette.interactions),
+        }
+    elif replay_cassette is not None:
+        cassette_info = {
+            "path": str(cassette_path),
+            "interactions": len(replay_cassette.interactions),
+            "mode": "replay",
+        }
 
     return {
         "test_name": tc.name,
         "run_type": "simulation",
         "simulation": result.model_dump(),
         "trace_count": len(traces) or 1,
+        "cassette": cassette_info,
     }
 
 
@@ -144,6 +183,25 @@ async def _run_one(
 @click.option("--seed", type=int, default=None, help="Override the seed declared in YAML.")
 @click.option("--variants", type=int, default=1, help="Run N deterministic replays (default: 1).")
 @click.option("--json", "json_output", is_flag=True, default=False, help="Emit JSON summary for CI.")
+@click.option(
+    "--record",
+    is_flag=True,
+    default=False,
+    help="Capture every real tool call into .evalview/cassettes/<test>.json for later replay.",
+)
+@click.option(
+    "--replay",
+    is_flag=True,
+    default=False,
+    help="Serve tool calls from the cassette at .evalview/cassettes/<test>.json (hermetic).",
+)
+@click.option(
+    "--cassette-dir",
+    type=click.Path(),
+    default=str(DEFAULT_CASSETTE_DIR),
+    show_default=True,
+    help="Override the directory used to find/store cassettes.",
+)
 @track_command("simulate")
 def simulate(
     test_path: str,
@@ -151,6 +209,9 @@ def simulate(
     seed: Optional[int],
     variants: int,
     json_output: bool,
+    record: bool,
+    replay: bool,
+    cassette_dir: str,
 ) -> None:
     """Run tests hermetically against declared mocks.
 
@@ -166,6 +227,9 @@ def simulate(
     """
     if variants < 1:
         raise click.ClickException("--variants must be >= 1")
+    if record and replay:
+        raise click.ClickException("--record and --replay are mutually exclusive.")
+    cassette_dir_path = Path(cassette_dir)
 
     cases = _resolve_test_cases(test_path, test_filter)
     if not cases:
@@ -179,7 +243,10 @@ def simulate(
     summaries: List[dict] = []
     for tc in cases:
         try:
-            summary = asyncio.run(_run_one(tc, config, variants, seed))
+            summary = asyncio.run(_run_one(
+                tc, config, variants, seed,
+                record=record, replay=replay, cassette_dir=cassette_dir_path,
+            ))
         except Exception as exc:
             summaries.append({
                 "test_name": tc.name,
@@ -202,6 +269,10 @@ def simulate(
                     sim["branches_explored"],
                 )
             )
+            if summary.get("cassette"):
+                ci = summary["cassette"]
+                verb = "Replayed" if ci.get("mode") == "replay" else "Recorded"
+                click.echo(f"  {verb} cassette: {ci['path']} ({ci['interactions']} interactions)")
 
     if json_output:
         click.echo(json.dumps({"results": summaries}, indent=2))

--- a/evalview/core/cassette.py
+++ b/evalview/core/cassette.py
@@ -1,0 +1,205 @@
+"""VCR-style record/replay cassettes for hermetic tool replay.
+
+The :mod:`simulation` engine already exposes a tool-mock seam via the
+``tool_executor`` adapter attribute. Cassettes turn that into a
+record-once / replay-forever workflow:
+
+* :class:`RecordingToolExecutor` wraps a real ``tool_executor`` and
+  captures every ``(tool, params) -> result`` (or error) into an
+  in-memory :class:`Cassette`. The orchestrator persists it to
+  ``.evalview/cassettes/<test-name>.json`` after the run.
+* :class:`ReplayToolExecutor` serves calls from a previously recorded
+  cassette, consuming entries per-tool in declaration order. Mismatches
+  raise :class:`CassetteMismatchError` under ``strict=True``; under
+  the default lenient mode they fall through to the wrapped real
+  executor (or return ``None`` if there is none).
+
+The matching strategy is **per-tool sequential**: calls to a given
+tool name consume that tool's recorded entries in order. This is
+robust to inter-tool ordering drift (the agent may legitimately call
+``lookup`` before or after ``check_policy`` on different runs) while
+still pinning intra-tool state (a tool called twice with the same
+params can return different values).
+
+Scope of the v1 cassette: tool calls only. LLM-response and HTTP
+cassettes follow the same shape but require adapter opt-in via
+``install_mock_interceptor`` and are tracked separately under the
+``response`` / ``http`` interaction kinds for future expansion. The
+JSON schema reserves the fields today so cassettes recorded now
+remain forward-compatible.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from evalview.core.types import Cassette, Interaction
+
+logger = logging.getLogger(__name__)
+
+
+CASSETTE_FORMAT_VERSION = 1
+DEFAULT_CASSETTE_DIR = Path(".evalview/cassettes")
+
+
+ToolExecutor = Callable[[str, Dict[str, Any]], Any]
+
+
+class CassetteError(RuntimeError):
+    """Base class for cassette errors."""
+
+
+class CassetteMismatchError(CassetteError):
+    """Raised when a strict replay encounters an unmatched call."""
+
+
+def cassette_path_for(test_name: str, root: Path = DEFAULT_CASSETTE_DIR) -> Path:
+    """Default on-disk location for a test's cassette.
+
+    Slashes in the name are replaced with ``__`` so multi-segment names
+    (e.g. ``billing/refund``) stay flat under the cassette dir.
+    """
+    safe = test_name.replace("/", "__").replace("\\", "__")
+    return root / f"{safe}.json"
+
+
+def save_cassette(cassette: Cassette, path: Path) -> None:
+    """Write a cassette to disk, creating parent directories as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(cassette.model_dump_json(indent=2))
+
+
+def load_cassette(path: Path) -> Cassette:
+    """Load a cassette JSON, validating the schema."""
+    raw = json.loads(path.read_text())
+    if raw.get("version", 0) > CASSETTE_FORMAT_VERSION:
+        raise CassetteError(
+            f"Cassette {path} was recorded with format v{raw['version']} "
+            f"but this evalview only understands up to v{CASSETTE_FORMAT_VERSION}. "
+            "Upgrade evalview or re-record."
+        )
+    return Cassette.model_validate(raw)
+
+
+@dataclass
+class RecordingToolExecutor:
+    """Wraps a real executor and records every call.
+
+    On each call, the wrapped executor runs first; the result (or the
+    error it raised) is then appended to ``interactions``. Errors are
+    captured and re-raised so the agent sees the same behavior it would
+    see live — recording is transparent.
+    """
+
+    real: ToolExecutor
+    interactions: List[Interaction] = field(default_factory=list)
+
+    def __call__(self, tool_name: str, params: Dict[str, Any]) -> Any:
+        try:
+            result = self.real(tool_name, params)
+        except Exception as exc:
+            self.interactions.append(Interaction(
+                kind="tool",
+                tool=tool_name,
+                params=dict(params or {}),
+                returns=None,
+                error=f"{type(exc).__name__}: {exc}",
+            ))
+            raise
+        self.interactions.append(Interaction(
+            kind="tool",
+            tool=tool_name,
+            params=dict(params or {}),
+            returns=result,
+            error=None,
+        ))
+        return result
+
+
+class ReplayToolExecutor:
+    """Serves tool calls from a cassette, consuming per-tool in order.
+
+    Per-tool sequential matching: each tool name has its own queue of
+    recorded interactions. Successive calls to the same tool consume
+    its queue in declaration order, which keeps replay deterministic
+    even when the agent shuffles inter-tool ordering between runs.
+
+    Behavior on a miss:
+    - ``strict=True``: raise :class:`CassetteMismatchError`.
+    - ``strict=False``: fall through to ``real`` if provided; else
+      return ``None`` and log at DEBUG.
+    """
+
+    def __init__(
+        self,
+        cassette: Cassette,
+        real: Optional[ToolExecutor] = None,
+        strict: bool = False,
+    ) -> None:
+        self._cassette = cassette
+        self._real = real
+        self._strict = strict
+        self._queues: Dict[str, List[Interaction]] = {}
+        for entry in cassette.interactions:
+            if entry.kind != "tool" or entry.tool is None:
+                continue
+            self._queues.setdefault(entry.tool, []).append(entry)
+        self.replays: List[Interaction] = []
+
+    def __call__(self, tool_name: str, params: Dict[str, Any]) -> Any:
+        queue = self._queues.get(tool_name)
+        if queue:
+            entry = queue.pop(0)
+            self.replays.append(entry)
+            if entry.error:
+                raise RuntimeError(entry.error)
+            return entry.returns
+
+        if self._strict:
+            raise CassetteMismatchError(
+                f"Cassette has no remaining recording for tool '{tool_name}' "
+                f"(strict mode). Re-record with --record or relax to lenient."
+            )
+        if self._real is not None:
+            logger.debug(
+                "Cassette miss for '%s'; falling through to real executor.",
+                tool_name,
+            )
+            return self._real(tool_name, params)
+        logger.debug("Cassette miss for '%s' with no real executor; returning None.", tool_name)
+        return None
+
+    def remaining(self) -> Dict[str, int]:
+        """Per-tool counts of unused recordings — surfaces over/under-replay."""
+        return {tool: len(q) for tool, q in self._queues.items() if q}
+
+
+def new_cassette(test_name: str, adapter: Optional[str] = None) -> Cassette:
+    """Build an empty cassette stamped with the current UTC time."""
+    return Cassette(
+        test_name=test_name,
+        recorded_at=datetime.now(timezone.utc).isoformat(),
+        adapter=adapter,
+        interactions=[],
+    )
+
+
+__all__ = [
+    "CASSETTE_FORMAT_VERSION",
+    "DEFAULT_CASSETTE_DIR",
+    "Cassette",
+    "CassetteError",
+    "CassetteMismatchError",
+    "Interaction",
+    "RecordingToolExecutor",
+    "ReplayToolExecutor",
+    "cassette_path_for",
+    "load_cassette",
+    "new_cassette",
+    "save_cassette",
+]

--- a/evalview/core/cassette.py
+++ b/evalview/core/cassette.py
@@ -33,10 +33,11 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Deque, Dict, List, Optional
 
 from evalview.core.types import Cassette, Interaction
 
@@ -144,17 +145,19 @@ class ReplayToolExecutor:
         self._cassette = cassette
         self._real = real
         self._strict = strict
-        self._queues: Dict[str, List[Interaction]] = {}
+        # Deques give O(1) popleft; lists are O(n) on pop(0), which
+        # would degrade replay of long recordings.
+        self._queues: Dict[str, Deque[Interaction]] = {}
         for entry in cassette.interactions:
             if entry.kind != "tool" or entry.tool is None:
                 continue
-            self._queues.setdefault(entry.tool, []).append(entry)
+            self._queues.setdefault(entry.tool, deque()).append(entry)
         self.replays: List[Interaction] = []
 
     def __call__(self, tool_name: str, params: Dict[str, Any]) -> Any:
         queue = self._queues.get(tool_name)
         if queue:
-            entry = queue.pop(0)
+            entry = queue.popleft()
             self.replays.append(entry)
             if entry.error:
                 raise RuntimeError(entry.error)

--- a/evalview/core/simulation.py
+++ b/evalview/core/simulation.py
@@ -35,6 +35,12 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from evalview.adapters.base import AgentAdapter
+from evalview.core.cassette import (
+    Cassette,
+    RecordingToolExecutor,
+    ReplayToolExecutor,
+    new_cassette,
+)
 from evalview.core.types import (
     AppliedMock,
     BranchExploration,
@@ -184,6 +190,56 @@ class Simulator:
         return hit
 
     # ------------------------------------------------------------------
+    # Internal: build the per-run executor stack
+    # ------------------------------------------------------------------
+
+    def _build_stack(
+        self,
+        rng: random.Random,
+        counter: _MockHitCounter,
+        replay_cassette: Optional[Cassette],
+        record_into: Optional[List["RecordingToolExecutor"]],
+    ) -> ToolExecutor:
+        """Layer the executor stack: mocks → recorder → (replay | real).
+
+        Order rationale:
+        - Declarative mocks always win first so users can override a
+          single cassette entry without re-recording the whole run.
+        - The recorder sits *below* mocks so synthetic mock results
+          never leak into a fresh cassette — only what the real layer
+          (or replay layer) actually returned.
+        - Replay, when present, replaces the real executor entirely;
+          it falls through to the real executor on a miss only when
+          ``MockSpec.strict`` is false.
+        """
+        real_executor = getattr(self._adapter, "tool_executor", None)
+
+        underlying: Optional[ToolExecutor]
+        if replay_cassette is not None:
+            underlying = ReplayToolExecutor(
+                replay_cassette,
+                real=real_executor,
+                strict=self._spec.strict,
+            )
+        else:
+            underlying = real_executor
+
+        if record_into is not None and underlying is not None:
+            recorder = RecordingToolExecutor(real=underlying)
+            record_into.append(recorder)
+            underlying = recorder
+
+        # When a replay cassette is installed, hermetic-strict semantics
+        # belong to the cassette layer, not the mock layer — otherwise
+        # the mock layer rejects any call that isn't explicitly mocked,
+        # never giving the cassette a chance to serve it.
+        mock_spec = self._spec
+        if replay_cassette is not None and self._spec.strict:
+            mock_spec = self._spec.model_copy(update={"strict": False})
+
+        return MockedToolExecutor(mock_spec, underlying, counter, rng)
+
+    # ------------------------------------------------------------------
     # Run entry points
     # ------------------------------------------------------------------
 
@@ -191,6 +247,9 @@ class Simulator:
         self,
         test_case: TestCase,
         seed_override: Optional[int] = None,
+        *,
+        replay_cassette: Optional[Cassette] = None,
+        record: bool = False,
     ) -> Tuple[ExecutionTrace, SimulationResult]:
         """Execute one simulated run and return (trace, SimulationResult).
 
@@ -199,13 +258,20 @@ class Simulator:
         convention). The original executor is restored after
         execution. Unmatched calls fall through unless ``spec.strict``
         is true.
+
+        When ``replay_cassette`` is provided, recorded tool results
+        serve calls in their place (per-tool sequential matching).
+        When ``record`` is true, the run captures every real tool call
+        into ``SimulationResult.recorded_cassette`` so the caller can
+        persist it with :func:`evalview.core.cassette.save_cassette`.
         """
         counter = _MockHitCounter()
         seed = self._spec.seed if seed_override is None else seed_override
         rng = random.Random(seed)
 
         real_executor = getattr(self._adapter, "tool_executor", None)
-        mocked = MockedToolExecutor(self._spec, real_executor, counter, rng)
+        recorders: Optional[List[RecordingToolExecutor]] = [] if record else None
+        mocked = self._build_stack(rng, counter, replay_cassette, recorders)
 
         # Install the mock layer via the adapter attribute rather than
         # the context dict — HTTP/streaming adapters JSON-serialize
@@ -235,6 +301,11 @@ class Simulator:
         # branch so the cloud UI always has something to render, even
         # when the agent only took the happy path.
         path = [f"{s.step_id}:{s.tool_name}" for s in trace.steps]
+        recorded_cassette: Optional[Cassette] = None
+        if recorders:
+            recorded_cassette = new_cassette(test_case.name, adapter=self._adapter.name)
+            for r in recorders:
+                recorded_cassette.interactions.extend(r.interactions)
         result = SimulationResult(
             seed=seed,
             mocks_applied=counter.to_applied(),
@@ -248,6 +319,7 @@ class Simulator:
                 )
             ],
             variant_outcomes=[],
+            recorded_cassette=recorded_cassette,
         )
         return trace, result
 
@@ -255,6 +327,9 @@ class Simulator:
         self,
         test_case: TestCase,
         variants: int,
+        *,
+        replay_cassette: Optional[Cassette] = None,
+        record: bool = False,
     ) -> Tuple[List[ExecutionTrace], SimulationResult]:
         """Fan out ``variants`` deterministic replays and aggregate.
 
@@ -263,6 +338,12 @@ class Simulator:
         the final output and cost/latency so cloud can render a pass/
         fail matrix. Scoring is left to the evaluator downstream —
         the simulator only reports raw outcomes.
+
+        ``replay_cassette`` and ``record`` behave the same as in
+        :meth:`run`. When recording, the cassette captures the
+        interactions from the *first* variant only — additional
+        variants would overwrite each other and reproducibility is
+        defined per-(test, seed) pair.
         """
         if variants < 1:
             raise ValueError("variants must be >= 1")
@@ -271,13 +352,17 @@ class Simulator:
         branches: List[BranchExploration] = []
         outcomes: List[VariantOutcome] = []
         combined_counter = _MockHitCounter()
+        recorded_cassette: Optional[Cassette] = None
 
         for i in range(variants):
             counter = _MockHitCounter()
             seed = (self._spec.seed or 0) + i
             rng = random.Random(seed)
             real_executor = getattr(self._adapter, "tool_executor", None)
-            mocked = MockedToolExecutor(self._spec, real_executor, counter, rng)
+            recorders: Optional[List[RecordingToolExecutor]] = (
+                [] if (record and i == 0) else None
+            )
+            mocked = self._build_stack(rng, counter, replay_cassette, recorders)
 
             context: Dict[str, Any] = dict(test_case.input.context or {})
             installer = getattr(self._adapter, "install_mock_interceptor", None)
@@ -301,6 +386,11 @@ class Simulator:
                 combined_counter.hits[(kind, matcher)] = (
                     combined_counter.hits.get((kind, matcher), 0) + count
                 )
+
+            if recorders:
+                recorded_cassette = new_cassette(test_case.name, adapter=self._adapter.name)
+                for r in recorders:
+                    recorded_cassette.interactions.extend(r.interactions)
 
             branch_id = f"b{i}"
             path = [f"{s.step_id}:{s.tool_name}" for s in trace.steps]
@@ -329,6 +419,7 @@ class Simulator:
             mocks_applied=combined_counter.to_applied(),
             branches_explored=branches,
             variant_outcomes=outcomes,
+            recorded_cassette=recorded_cassette,
         )
         return traces, result
 

--- a/evalview/core/simulation.py
+++ b/evalview/core/simulation.py
@@ -63,6 +63,40 @@ class UnmatchedMockError(RuntimeError):
     """Raised when ``MockSpec.strict`` is true and a call has no mock."""
 
 
+class UninterceptableAdapterError(RuntimeError):
+    """Raised when a hermetic-required run targets an adapter that has no
+    interception seam (no ``tool_executor``, no ``install_mock_interceptor``).
+
+    Without one of those hooks, mocks/cassettes/replay can't actually
+    install — the run would silently hit live services. Failing fast
+    is the only honest answer when the user has explicitly opted into
+    hermetic semantics via ``--record``, ``--replay``, or
+    ``MockSpec.strict=True``.
+    """
+
+
+def adapter_simulation_capability(adapter: AgentAdapter) -> Dict[str, bool]:
+    """Report which simulation layers an adapter can actually intercept.
+
+    Returns a dict with three booleans:
+        tools     — has a ``tool_executor`` attribute the simulator can swap.
+        responses — has ``install_mock_interceptor``, so it can pull
+                    LLM-response mocks from the simulator.
+        http      — declares ``supports_http_mocks=True`` (opt-in flag
+                    adapters set when they wire ``http_mock_for`` into
+                    their transport).
+
+    The check is intentionally cheap and side-effect-free so callers
+    can run it before every ``Simulator.run`` to decide whether to
+    warn / raise / proceed.
+    """
+    return {
+        "tools": hasattr(adapter, "tool_executor"),
+        "responses": callable(getattr(adapter, "install_mock_interceptor", None)),
+        "http": bool(getattr(adapter, "supports_http_mocks", False)),
+    }
+
+
 def _params_match(call_params: Dict[str, Any], match_params: Optional[Dict[str, Any]]) -> bool:
     """Subset-match: every key/value in ``match_params`` must equal the call."""
     if not match_params:
@@ -176,6 +210,52 @@ class Simulator:
         self._spec = spec
 
     # ------------------------------------------------------------------
+    # Internal: capability gate
+    # ------------------------------------------------------------------
+
+    def _check_capability(
+        self,
+        *,
+        replay: bool,
+        record: bool,
+        allow_live: bool,
+    ) -> Dict[str, bool]:
+        """Detect uninterceptable adapters before the run starts.
+
+        Three escalation tiers:
+          - Adapter has any interception seam → silent (capability is
+            still recorded on the result for transparency).
+          - No seam, but the user did not opt into hermetic semantics
+            (no record/replay, ``strict=False``) → log a warning and
+            proceed unless ``allow_live`` is set, in which case the
+            warning drops to INFO.
+          - No seam AND the user opted in (``record``, ``replay``, or
+            ``MockSpec.strict``) → raise
+            :class:`UninterceptableAdapterError` so the run fails fast
+            instead of silently going live.
+        """
+        cap = adapter_simulation_capability(self._adapter)
+        if any(cap.values()):
+            return cap
+
+        hermetic_required = record or replay or self._spec.strict
+        adapter_name = getattr(self._adapter, "name", type(self._adapter).__name__)
+        msg = (
+            f"Adapter '{adapter_name}' has no tool interception seam "
+            "(no `tool_executor`, no `install_mock_interceptor`, no "
+            "`supports_http_mocks`). Mocks/cassette/replay cannot be "
+            "installed — the run would hit live services. "
+            "See docs/SIMULATE.md#adapter-support-matrix."
+        )
+        if hermetic_required:
+            raise UninterceptableAdapterError(msg)
+        if allow_live:
+            logger.info(msg)
+        else:
+            logger.warning(msg)
+        return cap
+
+    # ------------------------------------------------------------------
     # Public helpers the CLI / adapters can import
     # ------------------------------------------------------------------
 
@@ -250,6 +330,7 @@ class Simulator:
         *,
         replay_cassette: Optional[Cassette] = None,
         record: bool = False,
+        allow_live: bool = False,
     ) -> Tuple[ExecutionTrace, SimulationResult]:
         """Execute one simulated run and return (trace, SimulationResult).
 
@@ -264,7 +345,19 @@ class Simulator:
         When ``record`` is true, the run captures every real tool call
         into ``SimulationResult.recorded_cassette`` so the caller can
         persist it with :func:`evalview.core.cassette.save_cassette`.
+
+        Raises :class:`UninterceptableAdapterError` when the run requires
+        hermetic semantics (``record``, ``replay_cassette``, or
+        ``MockSpec.strict``) but the adapter exposes no interception
+        seam. Otherwise an uninterceptable adapter logs a warning
+        (downgraded to INFO when ``allow_live=True``) and proceeds.
         """
+        capability = self._check_capability(
+            replay=replay_cassette is not None,
+            record=record,
+            allow_live=allow_live,
+        )
+
         counter = _MockHitCounter()
         seed = self._spec.seed if seed_override is None else seed_override
         rng = random.Random(seed)
@@ -320,6 +413,7 @@ class Simulator:
             ],
             variant_outcomes=[],
             recorded_cassette=recorded_cassette,
+            adapter_capability=capability,
         )
         return trace, result
 
@@ -330,6 +424,7 @@ class Simulator:
         *,
         replay_cassette: Optional[Cassette] = None,
         record: bool = False,
+        allow_live: bool = False,
     ) -> Tuple[List[ExecutionTrace], SimulationResult]:
         """Fan out ``variants`` deterministic replays and aggregate.
 
@@ -348,31 +443,40 @@ class Simulator:
         if variants < 1:
             raise ValueError("variants must be >= 1")
 
+        capability = self._check_capability(
+            replay=replay_cassette is not None,
+            record=record,
+            allow_live=allow_live,
+        )
+
         traces: List[ExecutionTrace] = []
         branches: List[BranchExploration] = []
         outcomes: List[VariantOutcome] = []
         combined_counter = _MockHitCounter()
         recorded_cassette: Optional[Cassette] = None
 
+        # Adapter is the same object across variants — resolve its
+        # interception attributes once.
+        real_executor = getattr(self._adapter, "tool_executor", None)
+        installer = getattr(self._adapter, "install_mock_interceptor", None)
+        had_attr = hasattr(self._adapter, "tool_executor")
+
         for i in range(variants):
             counter = _MockHitCounter()
             seed = (self._spec.seed or 0) + i
             rng = random.Random(seed)
-            real_executor = getattr(self._adapter, "tool_executor", None)
             recorders: Optional[List[RecordingToolExecutor]] = (
                 [] if (record and i == 0) else None
             )
             mocked = self._build_stack(rng, counter, replay_cassette, recorders)
 
             context: Dict[str, Any] = dict(test_case.input.context or {})
-            installer = getattr(self._adapter, "install_mock_interceptor", None)
             if callable(installer):
                 try:
                     installer(self)
                 except Exception as exc:  # pragma: no cover
                     logger.warning("install_mock_interceptor raised: %s", exc)
 
-            had_attr = hasattr(self._adapter, "tool_executor")
             if had_attr:
                 setattr(self._adapter, "tool_executor", mocked)
             try:
@@ -420,8 +524,15 @@ class Simulator:
             branches_explored=branches,
             variant_outcomes=outcomes,
             recorded_cassette=recorded_cassette,
+            adapter_capability=capability,
         )
         return traces, result
 
 
-__all__ = ["Simulator", "MockedToolExecutor", "UnmatchedMockError"]
+__all__ = [
+    "MockedToolExecutor",
+    "Simulator",
+    "UninterceptableAdapterError",
+    "UnmatchedMockError",
+    "adapter_simulation_capability",
+]

--- a/evalview/core/types.py
+++ b/evalview/core/types.py
@@ -579,6 +579,14 @@ class SimulationResult(BaseModel):
     branches_explored: List[BranchExploration] = Field(default_factory=list)
     variant_outcomes: List[VariantOutcome] = Field(default_factory=list)
     recorded_cassette: Optional[Cassette] = Field(default=None, exclude=True)
+    adapter_capability: Dict[str, bool] = Field(
+        default_factory=dict,
+        description=(
+            "Per-layer interception ability detected at run start: "
+            "tools / responses / http. All-false means the run hit "
+            "live services regardless of declared mocks."
+        ),
+    )
 
 
 # --- Execution Trace Types ---

--- a/evalview/core/types.py
+++ b/evalview/core/types.py
@@ -536,6 +536,31 @@ class VariantOutcome(BaseModel):
     notes: Optional[str] = None
 
 
+class Interaction(BaseModel):
+    """One recorded tool/LLM/HTTP call inside a :class:`Cassette`.
+
+    Only ``kind="tool"`` is consumed by the v1 replay path; the
+    ``response``/``http`` kinds are reserved so cassettes round-trip
+    forward when adapter-side hooks land for those layers.
+    """
+
+    kind: str = Field(default="tool", description="One of tool|response|http.")
+    tool: Optional[str] = None
+    params: Dict[str, Any] = Field(default_factory=dict)
+    returns: Any = None
+    error: Optional[str] = None
+
+
+class Cassette(BaseModel):
+    """A recorded set of interactions for hermetic replay of one test."""
+
+    version: int = Field(default=1)
+    test_name: str
+    recorded_at: str
+    adapter: Optional[str] = None
+    interactions: List[Interaction] = Field(default_factory=list)
+
+
 class SimulationResult(BaseModel):
     """Payload attached to an EvaluationResult when run under ``evalview simulate``.
 
@@ -543,12 +568,17 @@ class SimulationResult(BaseModel):
     existing GateResult fields. Cloud stores ``mocks_applied`` and
     ``branches_explored`` in the ``simulations`` table and renders them
     on the simulation tab; it never runs simulations itself.
+
+    ``recorded_cassette`` is populated only when the run was started
+    with ``record=True``; it is not persisted to cloud (the CLI
+    writes it to ``.evalview/cassettes/<test>.json`` instead).
     """
 
     seed: int = 0
     mocks_applied: List[AppliedMock] = Field(default_factory=list)
     branches_explored: List[BranchExploration] = Field(default_factory=list)
     variant_outcomes: List[VariantOutcome] = Field(default_factory=list)
+    recorded_cassette: Optional[Cassette] = Field(default=None, exclude=True)
 
 
 # --- Execution Trace Types ---

--- a/examples/simulation/README.md
+++ b/examples/simulation/README.md
@@ -1,16 +1,34 @@
 # Simulation examples
 
 Worked YAML files demonstrating `evalview simulate` — hermetic runs
-against declared mocks for tool calls, LLM responses, and HTTP.
+against declared mocks (or recorded cassettes) for tool calls, LLM
+responses, and HTTP.
 
 | File | What it shows |
 |---|---|
-| `flight-booking.yaml` | Tool mocks with subset param matching, a deliberate error-path mock, and expected-behavior assertions that fail if the agent picks the wrong flight. |
+| `flight-booking.yaml` | Declarative `mocks:` block with subset param matching, a deliberate error-path mock, and expected-behavior assertions that fail if the agent picks the wrong flight. |
+| `order-lookup-replay.yaml` + `cassettes/order-lookup-replay.json` | The cassette workflow: no `mocks:` block in the YAML, hermetic replay served entirely from a pre-recorded JSON cassette. |
 
-Run all examples:
+## Cassette walkthrough
+
+Cassettes capture real tool calls once and replay them deterministically
+forever — no live services in CI.
 
 ```bash
-evalview simulate examples/simulation/ --variants 3
+# Replay hermetically using the bundled cassette:
+evalview simulate examples/simulation/order-lookup-replay.yaml \
+  --replay --cassette-dir examples/simulation/cassettes
+
+# Re-record after the real backend changes (requires API keys):
+evalview simulate examples/simulation/order-lookup-replay.yaml \
+  --record --cassette-dir examples/simulation/cassettes
 ```
+
+The cassette format is documented in
+[`docs/SIMULATE.md`](../../docs/SIMULATE.md#record--replay-cassettes).
+Per-tool sequential matching keeps replay robust even when the agent
+reorders calls between runs; declarative `mocks:` (if present) take
+precedence so a single recording can be overridden without
+re-recording the whole run.
 
 See `docs/SIMULATE.md` for the full YAML schema and CLI reference.

--- a/examples/simulation/cassettes/order-lookup-replay.json
+++ b/examples/simulation/cassettes/order-lookup-replay.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "test_name": "order-lookup-replay",
+  "recorded_at": "2026-05-04T12:00:00+00:00",
+  "adapter": "anthropic",
+  "interactions": [
+    {
+      "kind": "tool",
+      "tool": "lookup_order",
+      "params": { "order_id": 4812 },
+      "returns": {
+        "id": 4812,
+        "customer": "alice@example.com",
+        "total": 99.0,
+        "placed_at": "2026-05-01T09:14:00Z"
+      },
+      "error": null
+    },
+    {
+      "kind": "tool",
+      "tool": "check_shipment",
+      "params": { "order_id": 4812 },
+      "returns": {
+        "status": "shipped",
+        "carrier": "UPS",
+        "tracking": "1Z999AA10123456784",
+        "eta": "2026-05-06"
+      },
+      "error": null
+    }
+  ]
+}

--- a/examples/simulation/order-lookup-replay.yaml
+++ b/examples/simulation/order-lookup-replay.yaml
@@ -1,0 +1,47 @@
+# Example: replay an order-lookup agent from a pre-recorded cassette.
+#
+# This test deliberately has no `mocks:` block — the hermetic replay
+# is provided by a cassette in cassettes/order-lookup-replay.json,
+# captured against a real backend on a previous run.
+#
+# Run hermetically:
+#   evalview simulate examples/simulation/order-lookup-replay.yaml \
+#     --replay --cassette-dir examples/simulation/cassettes
+#
+# Re-record (e.g. after the real backend changes):
+#   evalview simulate examples/simulation/order-lookup-replay.yaml \
+#     --record --cassette-dir examples/simulation/cassettes
+
+name: order-lookup-replay
+description: Look up an order and summarize its status using a recorded cassette.
+
+adapter: anthropic
+endpoint: claude-sonnet-4-5-20250929
+
+input:
+  query: What's the status of order 4812?
+
+expected:
+  tools: [lookup_order, check_shipment]
+  output:
+    contains: ["4812", "shipped"]
+    not_contains: [error]
+
+thresholds:
+  min_score: 70
+
+tools:
+  - name: lookup_order
+    description: Retrieve order details by id.
+    input_schema:
+      type: object
+      properties:
+        order_id: { type: integer }
+      required: [order_id]
+  - name: check_shipment
+    description: Get the latest shipment status for an order.
+    input_schema:
+      type: object
+      properties:
+        order_id: { type: integer }
+      required: [order_id]

--- a/tests/test_cassette.py
+++ b/tests/test_cassette.py
@@ -1,0 +1,364 @@
+"""Tests for record/replay cassettes (`evalview/core/cassette.py`).
+
+Covers the three cases that matter for "is this actually hermetic?":
+
+1. **Recording is transparent** — wrapping a real executor doesn't
+   change what the agent sees, but every call lands in the cassette.
+2. **Round-trip equivalence** — a recorded cassette, replayed, returns
+   the same values without ever invoking the real executor.
+3. **Strict semantics** — extra/missing calls behave correctly under
+   both lenient and strict modes; per-tool sequential matching is
+   robust to inter-tool ordering drift.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from evalview.adapters.base import AgentAdapter
+from evalview.core.cassette import (
+    CASSETTE_FORMAT_VERSION,
+    CassetteError,
+    CassetteMismatchError,
+    RecordingToolExecutor,
+    ReplayToolExecutor,
+    cassette_path_for,
+    load_cassette,
+    new_cassette,
+    save_cassette,
+)
+from evalview.core.simulation import Simulator
+from evalview.core.types import (
+    Cassette,
+    ExecutionMetrics,
+    ExecutionTrace,
+    ExpectedBehavior,
+    Interaction,
+    MockSpec,
+    StepMetrics,
+    StepTrace,
+    TestCase,
+    TestInput,
+    Thresholds,
+    ToolMock,
+)
+
+
+class _ScriptedAdapter(AgentAdapter):
+    """Adapter that walks a fixed plan, calling tool_executor for each step."""
+
+    def __init__(self, plan: List[Dict[str, Any]]) -> None:
+        self._plan = plan
+        self.tool_executor = None
+
+    @property
+    def name(self) -> str:
+        return "scripted"
+
+    async def execute(self, query: str, context: Optional[Dict[str, Any]] = None) -> ExecutionTrace:
+        executor = self.tool_executor
+        assert executor is not None
+        steps: List[StepTrace] = []
+        outputs: List[str] = []
+        for i, call in enumerate(self._plan):
+            result = executor(call["tool"], call["params"])
+            outputs.append(str(result))
+            steps.append(StepTrace(
+                step_id=f"step-{i}",
+                step_name=call["tool"],
+                tool_name=call["tool"],
+                parameters=call["params"],
+                output=result,
+                success=True,
+                metrics=StepMetrics(latency=1.0, cost=0.0),
+            ))
+        return ExecutionTrace(
+            session_id="t",
+            start_time=datetime(2026, 5, 4, 10, 0, 0),
+            end_time=datetime(2026, 5, 4, 10, 0, 1),
+            steps=steps,
+            final_output=" | ".join(outputs),
+            metrics=ExecutionMetrics(total_cost=0.0, total_latency=1.0),
+        )
+
+
+def _case(name: str = "t", mocks: Optional[MockSpec] = None) -> TestCase:
+    return TestCase(
+        name=name,
+        input=TestInput(query="q"),
+        expected=ExpectedBehavior(),
+        thresholds=Thresholds(min_score=0),
+        mocks=mocks,
+    )
+
+
+# ============================================================================
+# RecordingToolExecutor — transparent capture
+# ============================================================================
+
+
+class TestRecordingToolExecutor:
+    def test_records_each_call_with_result(self):
+        def real(name, params):
+            return {"echo": name, "p": params}
+
+        rec = RecordingToolExecutor(real=real)
+        assert rec("search", {"q": "paris"}) == {"echo": "search", "p": {"q": "paris"}}
+        assert rec("lookup", {"id": 1}) == {"echo": "lookup", "p": {"id": 1}}
+
+        assert [i.tool for i in rec.interactions] == ["search", "lookup"]
+        assert rec.interactions[0].returns == {"echo": "search", "p": {"q": "paris"}}
+        assert rec.interactions[0].error is None
+
+    def test_records_errors_then_reraises(self):
+        def real(name, params):
+            raise ValueError("upstream boom")
+
+        rec = RecordingToolExecutor(real=real)
+        with pytest.raises(ValueError, match="upstream boom"):
+            rec("flaky", {})
+        assert len(rec.interactions) == 1
+        assert rec.interactions[0].error == "ValueError: upstream boom"
+        assert rec.interactions[0].returns is None
+
+    def test_params_are_copied_not_aliased(self):
+        """Mutating the params dict after recording must not alter the cassette."""
+        def real(name, params):
+            return None
+
+        rec = RecordingToolExecutor(real=real)
+        params = {"q": "v1"}
+        rec("search", params)
+        params["q"] = "v2"
+        assert rec.interactions[0].params == {"q": "v1"}
+
+
+# ============================================================================
+# ReplayToolExecutor — hermetic playback
+# ============================================================================
+
+
+class TestReplayToolExecutor:
+    def _cassette(self, *interactions: Interaction) -> Cassette:
+        return Cassette(
+            test_name="t",
+            recorded_at="2026-05-04T00:00:00Z",
+            interactions=list(interactions),
+        )
+
+    def test_serves_calls_in_recorded_order_per_tool(self):
+        cas = self._cassette(
+            Interaction(tool="search", params={}, returns="r1"),
+            Interaction(tool="search", params={}, returns="r2"),
+        )
+        rep = ReplayToolExecutor(cas)
+        assert rep("search", {}) == "r1"
+        assert rep("search", {}) == "r2"
+
+    def test_intertool_order_does_not_matter(self):
+        """The agent may reorder lookup vs check_policy between runs.
+
+        Per-tool sequential matching keeps replay deterministic anyway:
+        each tool name has its own queue, so calls consume independently.
+        """
+        cas = self._cassette(
+            Interaction(tool="lookup", params={}, returns="L1"),
+            Interaction(tool="check_policy", params={}, returns="P1"),
+            Interaction(tool="lookup", params={}, returns="L2"),
+        )
+        rep = ReplayToolExecutor(cas)
+        assert rep("check_policy", {}) == "P1"
+        assert rep("lookup", {}) == "L1"
+        assert rep("lookup", {}) == "L2"
+
+    def test_replays_recorded_errors(self):
+        cas = self._cassette(
+            Interaction(tool="flaky", error="RuntimeError: boom"),
+        )
+        rep = ReplayToolExecutor(cas)
+        with pytest.raises(RuntimeError, match="RuntimeError: boom"):
+            rep("flaky", {})
+
+    def test_strict_raises_on_unmatched(self):
+        cas = self._cassette(Interaction(tool="search", returns="r"))
+        rep = ReplayToolExecutor(cas, strict=True)
+        with pytest.raises(CassetteMismatchError):
+            rep("unrecorded", {})
+
+    def test_lenient_falls_through_to_real(self):
+        cas = self._cassette(Interaction(tool="search", returns="r"))
+        live: List[str] = []
+
+        def real(name, params):
+            live.append(name)
+            return "live"
+
+        rep = ReplayToolExecutor(cas, real=real, strict=False)
+        assert rep("unrecorded", {}) == "live"
+        assert live == ["unrecorded"]
+
+    def test_lenient_returns_none_with_no_real(self):
+        cas = self._cassette(Interaction(tool="search", returns="r"))
+        rep = ReplayToolExecutor(cas, real=None, strict=False)
+        assert rep("unrecorded", {}) is None
+
+    def test_remaining_reports_unused(self):
+        cas = self._cassette(
+            Interaction(tool="search", returns="r1"),
+            Interaction(tool="search", returns="r2"),
+        )
+        rep = ReplayToolExecutor(cas)
+        rep("search", {})
+        assert rep.remaining() == {"search": 1}
+
+
+# ============================================================================
+# On-disk format — versioning + round-trip
+# ============================================================================
+
+
+class TestCassettePersistence:
+    def test_save_and_load_round_trip(self, tmp_path: Path):
+        cas = new_cassette("my-test", adapter="anthropic")
+        cas.interactions.append(Interaction(tool="search", params={"q": "x"}, returns=[1, 2, 3]))
+        path = tmp_path / "c.json"
+        save_cassette(cas, path)
+        loaded = load_cassette(path)
+        assert loaded.test_name == "my-test"
+        assert loaded.adapter == "anthropic"
+        assert loaded.version == CASSETTE_FORMAT_VERSION
+        assert loaded.interactions[0].tool == "search"
+        assert loaded.interactions[0].returns == [1, 2, 3]
+
+    def test_load_rejects_future_version(self, tmp_path: Path):
+        path = tmp_path / "c.json"
+        path.write_text('{"version": 99, "test_name": "t", "recorded_at": "x", "interactions": []}')
+        with pytest.raises(CassetteError, match="format v99"):
+            load_cassette(path)
+
+    def test_cassette_path_replaces_slashes(self):
+        p = cassette_path_for("billing/refund")
+        assert p.name == "billing__refund.json"
+
+
+# ============================================================================
+# End-to-end: record once, replay deterministically
+# ============================================================================
+
+
+class TestRoundTripWithSimulator:
+    @pytest.mark.asyncio
+    async def test_record_then_replay_yields_same_outputs(self, tmp_path: Path):
+        # The "real" tool is a counter that returns a different value each
+        # call. If replay actually serves from the cassette (and not from
+        # the live counter), the second pass must produce identical output.
+        counter = {"n": 0}
+
+        def real(name, params):
+            counter["n"] += 1
+            return f"call-{counter['n']}-{name}"
+
+        plan = [
+            {"tool": "alpha", "params": {}},
+            {"tool": "beta", "params": {}},
+            {"tool": "alpha", "params": {}},
+        ]
+
+        # ── Record pass ──
+        record_adapter = _ScriptedAdapter(plan)
+        record_adapter.tool_executor = real
+        sim = Simulator(record_adapter, MockSpec())
+        rec_trace, rec_result = await sim.run(_case("rt"), record=True)
+
+        assert rec_result.recorded_cassette is not None
+        cassette = rec_result.recorded_cassette
+        assert len(cassette.interactions) == 3
+        assert cassette.adapter == "scripted"
+
+        path = tmp_path / "rt.json"
+        save_cassette(cassette, path)
+
+        # ── Replay pass ── against an executor that would explode if used.
+        def must_not_call(name, params):
+            raise AssertionError(f"replay leaked to live executor: {name}")
+
+        replay_adapter = _ScriptedAdapter(plan)
+        replay_adapter.tool_executor = must_not_call
+        sim2 = Simulator(replay_adapter, MockSpec(strict=True))
+        loaded = load_cassette(path)
+        rep_trace, _ = await sim2.run(_case("rt"), replay_cassette=loaded)
+
+        # Replay outputs match what was recorded — not what `real` would
+        # return now (counter has advanced).
+        assert rep_trace.final_output == rec_trace.final_output
+
+    @pytest.mark.asyncio
+    async def test_recording_skipped_for_mocked_calls(self):
+        """Synthetic mock results must not pollute the cassette."""
+        live_calls: List[str] = []
+
+        def real(name, params):
+            live_calls.append(name)
+            return f"live-{name}"
+
+        plan = [
+            {"tool": "mocked_tool", "params": {}},
+            {"tool": "live_tool", "params": {}},
+        ]
+        adapter = _ScriptedAdapter(plan)
+        adapter.tool_executor = real
+
+        spec = MockSpec(tool_mocks=[ToolMock(tool="mocked_tool", returns="from-mock")])
+        _, result = await Simulator(adapter, spec).run(_case("mix"), record=True)
+
+        cas = result.recorded_cassette
+        assert cas is not None
+        # Only the unmocked tool reached the recorder.
+        assert [i.tool for i in cas.interactions] == ["live_tool"]
+        assert live_calls == ["live_tool"]
+
+
+# ============================================================================
+# CLI integration
+# ============================================================================
+
+
+class TestSimulateCassetteCLI:
+    def test_record_and_replay_flags_mutually_exclusive(self, tmp_path: Path):
+        from evalview.commands.simulate_cmd import simulate
+
+        (tmp_path / "t.yaml").write_text(yaml.safe_dump({
+            "name": "t",
+            "input": {"query": "x"},
+            "expected": {},
+            "thresholds": {"min_score": 0},
+        }))
+        runner = CliRunner()
+        result = runner.invoke(simulate, [str(tmp_path), "--record", "--replay"])
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output.lower()
+
+    def test_replay_without_cassette_errors(self, tmp_path: Path):
+        from evalview.commands.simulate_cmd import simulate
+
+        (tmp_path / "t.yaml").write_text(yaml.safe_dump({
+            "name": "no-cassette",
+            "adapter": "http",
+            "endpoint": "http://127.0.0.1:9999",
+            "input": {"query": "x"},
+            "expected": {},
+            "thresholds": {"min_score": 0},
+        }))
+        runner = CliRunner()
+        result = runner.invoke(
+            simulate,
+            [str(tmp_path), "--replay", "--cassette-dir", str(tmp_path / "c")],
+        )
+        assert result.exit_code != 0
+        assert "no cassette found" in result.output.lower()

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -249,6 +249,102 @@ class TestSimulatorVariants:
 
 
 # ============================================================================
+# Adapter capability check — uninterceptable adapters fail loudly
+# ============================================================================
+
+
+class _UninterceptableAdapter(AgentAdapter):
+    """Adapter with no `tool_executor` and no `install_mock_interceptor`.
+
+    Models the LangGraph-Cloud / generic-HTTP case where the agent
+    runs server-side and there's no in-process seam for the simulator
+    to swap. Returns a trivial trace if it ever gets called.
+    """
+
+    @property
+    def name(self) -> str:
+        return "uninterceptable"
+
+    async def execute(self, query, context=None):
+        return ExecutionTrace(
+            session_id="u",
+            start_time=datetime(2026, 4, 20, 10, 0, 0),
+            end_time=datetime(2026, 4, 20, 10, 0, 1),
+            steps=[],
+            final_output="",
+            metrics=ExecutionMetrics(total_cost=0.0, total_latency=0.0),
+        )
+
+
+class TestAdapterCapability:
+    def test_capability_reports_truthfully(self):
+        from evalview.core.simulation import adapter_simulation_capability
+
+        cap_full = adapter_simulation_capability(_FakeAdapter(plan=[]))
+        # _FakeAdapter exposes both seams.
+        assert cap_full == {"tools": True, "responses": True, "http": False}
+
+        cap_none = adapter_simulation_capability(_UninterceptableAdapter())
+        assert cap_none == {"tools": False, "responses": False, "http": False}
+
+    @pytest.mark.asyncio
+    async def test_strict_raises_on_uninterceptable(self):
+        from evalview.core.simulation import UninterceptableAdapterError
+
+        sim = Simulator(_UninterceptableAdapter(), MockSpec(strict=True))
+        with pytest.raises(UninterceptableAdapterError, match="no tool interception seam"):
+            await sim.run(_case())
+
+    @pytest.mark.asyncio
+    async def test_record_raises_on_uninterceptable(self):
+        from evalview.core.simulation import UninterceptableAdapterError
+
+        sim = Simulator(_UninterceptableAdapter(), MockSpec())
+        with pytest.raises(UninterceptableAdapterError):
+            await sim.run(_case(), record=True)
+
+    @pytest.mark.asyncio
+    async def test_replay_raises_on_uninterceptable(self):
+        from evalview.core.simulation import UninterceptableAdapterError
+        from evalview.core.types import Cassette as _Cassette
+
+        cassette = _Cassette(test_name="t", recorded_at="x", interactions=[])
+        sim = Simulator(_UninterceptableAdapter(), MockSpec())
+        with pytest.raises(UninterceptableAdapterError):
+            await sim.run(_case(), replay_cassette=cassette)
+
+    @pytest.mark.asyncio
+    async def test_lenient_warns_but_proceeds(self, caplog):
+        # No record / replay / strict — uninterceptable run is allowed
+        # but must surface a WARNING so the user knows the run is live.
+        import logging
+        sim = Simulator(_UninterceptableAdapter(), MockSpec())
+        with caplog.at_level(logging.WARNING, logger="evalview.core.simulation"):
+            _, result = await sim.run(_case())
+        assert any("no tool interception seam" in r.message for r in caplog.records)
+        assert result.adapter_capability == {"tools": False, "responses": False, "http": False}
+
+    @pytest.mark.asyncio
+    async def test_allow_live_downgrades_warning_to_info(self, caplog):
+        import logging
+        sim = Simulator(_UninterceptableAdapter(), MockSpec())
+        with caplog.at_level(logging.DEBUG, logger="evalview.core.simulation"):
+            await sim.run(_case(), allow_live=True)
+        # Same message, but at INFO level (no WARNING).
+        warns = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        infos = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert not warns
+        assert any("no tool interception seam" in r.message for r in infos)
+
+    @pytest.mark.asyncio
+    async def test_capability_recorded_on_interceptable_adapter(self):
+        sim = Simulator(_FakeAdapter(plan=[]), MockSpec())
+        _, result = await sim.run(_case())
+        assert result.adapter_capability["tools"] is True
+        assert result.adapter_capability["responses"] is True
+
+
+# ============================================================================
 # Response / HTTP mock matching (public helpers)
 # ============================================================================
 


### PR DESCRIPTION
## Description

This PR adds VCR-style record/replay cassettes to `evalview simulate`, enabling deterministic hermetic replay of tool calls without re-hitting live services. Users can now capture real tool interactions once with `--record`, then replay them forever with `--replay` for reproducible CI runs.

The implementation includes:

1. **New `evalview/core/cassette.py` module** with:
   - `RecordingToolExecutor`: wraps a real executor and transparently captures every `(tool, params) → result` interaction
   - `ReplayToolExecutor`: serves calls from a cassette using per-tool sequential matching (robust to inter-tool ordering drift)
   - Cassette persistence (`save_cassette`, `load_cassette`) with versioning for forward compatibility
   - `CassetteMismatchError` for strict replay violations

2. **Adapter capability detection** (`adapter_simulation_capability()` in `simulation.py`):
   - Probes adapters for three interception layers: `tools`, `responses`, `http`
   - Raises `UninterceptableAdapterError` when `--record`/`--replay`/`strict=True` targets an adapter with no seams
   - Logs warnings for lenient runs against uninterceptable adapters (suppressible with `--allow-live`)

3. **CLI integration** (`simulate_cmd.py`):
   - New flags: `--record`, `--replay`, `--cassette-dir`, `--allow-live`
   - Cassettes stored at `.evalview/cassettes/<test-name>.json`
   - Human output now shows adapter capability matrix

4. **Type system updates** (`types.py`):
   - New `Interaction` and `Cassette` models
   - `SimulationResult.adapter_capability` field for transparency

5. **Comprehensive test coverage** (`test_cassette.py`):
   - Recording transparency (wrapping doesn't change agent behavior)
   - Round-trip equivalence (recorded → replayed yields identical outputs)
   - Strict vs. lenient replay semantics
   - Per-tool sequential matching robustness
   - End-to-end simulator integration

## Related Issue

Addresses reproducibility gap where reproducing "agent saw X, called Y, got Z" required hitting live services again.

## Type of Change

- [x] New feature (record/replay cassettes for hermetic simulation)
- [x] Documentation update (SIMULATE.md, design doc, examples)
- [x] Test improvements (364-line test suite for cassettes)

## Changes Made

- Added `evalview/core/cassette.py` (208 lines) with `RecordingToolExecutor`, `ReplayToolExecutor`, and persistence helpers
- Extended `evalview/core/simulation.py` with capability detection, executor stack building, and `--record`/`--replay` support
- Updated `evalview/commands/simulate_cmd.py` to wire CLI flags and render capability matrix
- Added `Interaction` and `Cassette` types to `evalview/core/types.py`
- Extended `SimulationResult` with `adapter_capability` field
- Added design doc `docs/design/loud-skip-warning.md` explaining the capability check rationale
- Updated `docs/SIMULATE.md` with cassette workflow and adapter matrix
- Added example test `examples/simulation/order-lookup-replay.yaml` + pre-recorded cassette
- Updated CHANGELOG.md and README.md

## Testing

### Tests Added/Modified

- [x] Unit tests added: `tests/test_cassette.py` (364 lines)
  - `TestRecordingToolExecutor`: transparent capture, error handling, param copying
  - `TestReplayToolExecutor`: per-tool sequential matching, inter-tool ordering robustness, strict/lenient modes
  - `TestCassettePersistence`: round-trip JSON serialization, version validation
  - `TestRoundTripWithSimulator`: end-to-end record→replay with counter verification
  - `TestSimulateCassetteCLI`: CLI flag integration
- [x] Integration tests added: `tests/test_simulation.py`
  - `TestAdapterCap

https://claude.ai/code/session_018R3LMVCTfPcRRHUBqzWJff