### PR TITLE
feat(simulate): record/replay cassettes + loud capability check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Record/replay cassettes for `evalview simulate`** — capture real
+  tool calls once, replay deterministically forever. Closes the
+  reproducibility gap where reproducing "agent saw X, called Y, got Z"
+  required hitting live services again. Cassettes live at
+  `.evalview/cassettes/<test>.json`, are versioned for forward compat,
+  and use per-tool sequential matching so inter-tool ordering drift
+  doesn't break replay. New flags: `--record`, `--replay`,
+  `--cassette-dir`. Declarative `mocks:` still take precedence so a
+  single recording can be overridden without re-recording the whole
+  run. See `docs/SIMULATE.md#record--replay-cassettes`.
+- **Adapter capability check for simulation** — `Simulator` now
+  detects when an adapter has no tool interception seam (no
+  `tool_executor` attribute, no `install_mock_interceptor`) and
+  fails fast under `--record` / `--replay` / `mocks.strict=true`
+  instead of silently letting the run hit live services. Lenient
+  mode logs a warning unless `--allow-live` is set.
+  `SimulationResult.adapter_capability` records the truth so JSON/CI
+  consumers can see whether interception was actually possible. See
+  `docs/design/loud-skip-warning.md`.
+
 ## [0.7.1] - 2026-05-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Most eval tools stop at detect and compare. EvalView helps you classify changes,
 - Catch silent regressions that normal tests miss
 - Separate provider/model drift from real system regressions
 - Auto-heal flaky failures with retries, review gates, and audit logs
+- Replay deterministically — cassettes capture real tool calls once so CI never re-hits live services
 
 Built for **frontier-lab rigor, startup-team practicality**:
 - targeted behavior runs instead of giant always-on eval suites
@@ -269,6 +270,7 @@ Use LangSmith for observability. Use Braintrust for scoring. **Use EvalView for 
 | Golden baseline regression | — | Manual | — | **Automatic** |
 | Silent model change detection | — | — | — | **Yes** |
 | Auto-heal (retry + variant proposal) | — | — | — | **Yes** |
+| Hermetic record/replay | — | — | — | **Yes** |
 | PR comments with alerts | — | — | — | **Cost, latency, model change** |
 | Works without API keys | No | No | Partial | **Yes** |
 | Production monitoring | Tracing | — | — | **Check loop + Slack** |
@@ -704,6 +706,15 @@ Two features that close the gaps the April 2026 agent-eval reports kept calling 
 evalview simulate tests/ --variants 5 --seed 42
 ```
 
+**Record/replay cassettes** — declarative mocks are tedious for agents with dozens of tools. Record once against the real backend, replay forever — no network, no LLM cost beyond the agent's own model calls, no flaky third-party APIs in CI. *"The agent saw X, called Y, got Z"* becomes deterministic without re-hitting live services.
+
+```bash
+evalview simulate tests/refund.yaml --record    # capture real tool results once
+evalview simulate tests/refund.yaml --replay    # hermetic from now on
+```
+
+Cassettes live at `.evalview/cassettes/<test>.json`, use per-tool sequential matching (robust to inter-tool ordering drift), and are versioned for forward compatibility. Declarative `mocks:` still take precedence so you can override a single recording without re-recording the whole run.
+
 **Decision rationale** — every tool_choice / branch gets recorded with the chosen option, alternatives considered, and any model-reported reasoning (Anthropic `thinking` blocks auto-captured). Grouped across runs by `input_hash` so cloud analytics surfaces decision drift before your users notice. Local HTML replay shows it inline.
 
 Supported adapters: Anthropic, OpenAI Assistants, LangGraph, CrewAI native.
@@ -722,6 +733,7 @@ Supported adapters: Anthropic, OpenAI Assistants, LangGraph, CrewAI native.
 | **Recommendation engine** | Suggests the next command from verdict, drift class, and history | [Above](#daily-workflow) |
 | **Model drift detection** | `model-check` — zero-judge canary suite that catches silent model updates | [Docs](#model-drift-detection) |
 | **Simulation harness** | `evalview simulate` — hermetic what-if runs against declared mocks, with `--variants N` fan-out | [Docs](docs/SIMULATE.md) |
+| **Record/replay cassettes** | Capture real tool calls once, replay deterministically forever — no live services in CI | [Docs](docs/SIMULATE.md#record--replay-cassettes) |
 | **Decision rationale** | Structured `tool_choice` / `branch` logging with cross-run grouping for decision-drift detection | [Docs](docs/RATIONALE.md) |
 | **Assertion wizard** | Analyze captured traffic, suggest smart assertions automatically | [Above](#assertion-wizard--tests-from-real-traffic) |
 | **Auto-variant discovery** | Run N times, cluster paths, save valid variants | [Above](#auto-variant-discovery--solve-non-determinism) |

--- a/docs/SIMULATE.md
+++ b/docs/SIMULATE.md
@@ -192,15 +192,71 @@ Aggregate output:
 ```
 evalview simulate [TEST_PATH] [OPTIONS]
 
-TEST_PATH      Directory (default: tests/) or single YAML file.
+TEST_PATH        Directory (default: tests/) or single YAML file.
 
--t, --test     Run only this test by name.
-    --seed     Override the seed declared in YAML.
-    --variants Run N deterministic replays (default: 1).
-    --json     Emit JSON summary for CI.
+-t, --test       Run only this test by name.
+    --seed       Override the seed declared in YAML.
+    --variants   Run N deterministic replays (default: 1).
+    --json       Emit JSON summary for CI.
+    --record     Capture every real tool call into a cassette under
+                 .evalview/cassettes/<test>.json.
+    --replay     Serve tool calls from the cassette at the same path
+                 (hermetic — never touches the network).
+    --cassette-dir DIR
+                 Override the cassette directory (default: .evalview/cassettes).
 ```
 
 Exit code 1 on any test error; 0 on success.
+
+## Record / replay cassettes
+
+Declarative `mocks:` are great when you know exactly what each tool
+should return, but they're tedious for agents with dozens of tools or
+variable params. Cassettes solve that — record once against the real
+backend, replay forever:
+
+```bash
+# 1. Once, against a live backend (or a staging fixture):
+evalview simulate tests/refund.yaml --record
+
+# 2. Forever after, hermetically — no network, no LLM cost beyond the
+#    agent's own model calls (which can be mocked separately):
+evalview simulate tests/refund.yaml --replay
+```
+
+Cassettes live at `.evalview/cassettes/<test-name>.json` and look like:
+
+```json
+{
+  "version": 1,
+  "test_name": "refund",
+  "recorded_at": "2026-05-04T12:34:56+00:00",
+  "adapter": "anthropic",
+  "interactions": [
+    {"kind": "tool", "tool": "lookup_order", "params": {"id": 4812}, "returns": {"id": 4812, "total": 99.0}, "error": null},
+    {"kind": "tool", "tool": "process_refund", "params": {"id": 4812}, "returns": {"status": "ok"}, "error": null}
+  ]
+}
+```
+
+**Matching rules.** Per-tool sequential: each tool name has its own
+queue of recordings, consumed in declaration order. The agent can
+legitimately reorder `lookup_order` vs `check_policy` between runs and
+replay still works — only intra-tool sequence matters.
+
+**Precedence.** If both a declarative `mocks:` block and a cassette
+exist, declarative mocks win first (so you can override a single
+recording without re-recording the whole run); cassette serves the
+rest; live executor serves anything still unmatched (unless
+`mocks.strict=true`, in which case unmatched calls raise).
+
+**Recording is transparent.** The recorder runs the real executor
+first, then captures the result. Errors are recorded too and re-raised
+from replay, so the agent sees identical behavior either way.
+
+**Synthetic mocks are not recorded.** Calls that hit a declarative
+`tool_mocks` entry never reach the recorder — the cassette only
+captures what the real layer actually returned.
 
 ## Adapter support matrix
 

--- a/docs/SIMULATE.md
+++ b/docs/SIMULATE.md
@@ -204,9 +204,36 @@ TEST_PATH        Directory (default: tests/) or single YAML file.
                  (hermetic — never touches the network).
     --cassette-dir DIR
                  Override the cassette directory (default: .evalview/cassettes).
+    --allow-live Suppress the warning when the adapter has no
+                 interception seam. Hermetic modes still raise.
 ```
 
 Exit code 1 on any test error; 0 on success.
+
+## Adapter capability check
+
+Before every run, the simulator probes the adapter for three
+interception layers:
+
+| Layer | Detection | Purpose |
+|---|---|---|
+| `tools` | `hasattr(adapter, "tool_executor")` | Tool-call swap (the path mocks/cassettes use). |
+| `responses` | `callable(adapter.install_mock_interceptor)` | LLM-response pull hooks. |
+| `http` | `getattr(adapter, "supports_http_mocks", False)` | Outbound HTTP intercept opt-in. |
+
+The result lands on `SimulationResult.adapter_capability` and renders
+under "Adapter capability:" in the human output.
+
+**When the adapter has none of the three** (e.g. an HTTP/streaming
+adapter where the agent runs server-side), the simulator escalates:
+
+| Run mode | Behavior |
+|---|---|
+| Lenient (no `--record` / `--replay` / `mocks.strict`) | Logs a `WARNING`. Drops to `INFO` with `--allow-live`. |
+| Hermetic (`--record`, `--replay`, or `mocks.strict=true`) | Raises `UninterceptableAdapterError` before any live call. |
+
+This means a `--replay` against an unsupported adapter fails fast
+instead of silently going live with an empty mock layer.
 
 ## Record / replay cassettes
 

--- a/docs/design/loud-skip-warning.md
+++ b/docs/design/loud-skip-warning.md
@@ -1,0 +1,196 @@
+# Design: loud failure when simulation can't actually intercept
+
+**Status:** proposed
+**Author:** EvalView reproducibility track
+**Companion:** [SIMULATE.md](../SIMULATE.md), [`evalview/core/cassette.py`](../../evalview/core/cassette.py)
+
+## Problem
+
+The `Simulator` installs mocks/cassettes by **monkey-patching the
+adapter's `tool_executor` attribute** ([`simulation.py:225`](../../evalview/core/simulation.py)):
+
+```python
+had_attr = hasattr(self._adapter, "tool_executor")
+if had_attr:
+    setattr(self._adapter, "tool_executor", mocked)
+```
+
+When `had_attr` is false — the adapter has no `tool_executor` attribute
+to patch and no `install_mock_interceptor` either — the simulator
+**silently skips installation**. The agent runs against live
+dependencies. There is currently no warning, no error, and no
+indication in the output.
+
+This breaks the "hermetic CI" promise for at least these adapters
+(based on `grep "tool_executor" evalview/adapters/`):
+
+| Adapter | Has `tool_executor`? | Has `install_mock_interceptor`? |
+|---|---|---|
+| anthropic_adapter.py | ✅ | — |
+| openai_assistants_adapter.py | unknown — needs audit | unknown |
+| crewai_native_adapter.py | unknown | unknown |
+| http_adapter.py | ❌ (calls happen server-side) | — |
+| langgraph_adapter.py | likely ❌ for cloud, ✅ for native | — |
+| ollama_adapter.py | unknown | unknown |
+| mcp_adapter.py | unknown | unknown |
+| (others) | unknown | unknown |
+
+A user who runs `evalview simulate --strict` (or `--replay`) against
+an HTTP/streaming adapter will see "Mocks applied: none matched" — the
+same output they'd see if their declarative mocks just didn't match.
+There is no way to tell whether the run was hermetic or live.
+
+## Goal
+
+Make it impossible to run `simulate`/`replay`/`record` against an
+uninterceptable adapter without knowing it.
+
+## Non-goals
+
+- **Don't refuse to run.** Some users explicitly want `simulate` to
+  fan out variants against a partially-live adapter. The signal is
+  what changes; the run still goes.
+- **Don't try to add interception** to remote adapters here. That's a
+  separate, larger effort (e.g. server-side `install_mock_interceptor`,
+  HTTP-transport wrapping). This design only fixes visibility.
+
+## Proposal
+
+### 1. Capability check on the adapter
+
+Add a small helper in `evalview/core/simulation.py`:
+
+```python
+def adapter_simulation_capability(adapter) -> dict:
+    """Report which simulation layers this adapter actually supports.
+
+    Returns a dict with three booleans:
+      tools:     can intercept tool calls (has tool_executor attr)
+      responses: can intercept LLM responses (has install_mock_interceptor)
+      http:      can intercept outbound HTTP (declares supports_http_mocks)
+    """
+    return {
+        "tools": hasattr(adapter, "tool_executor"),
+        "responses": callable(getattr(adapter, "install_mock_interceptor", None)),
+        "http": bool(getattr(adapter, "supports_http_mocks", False)),
+    }
+```
+
+### 2. Three escalation tiers
+
+| Condition | Behavior | Where |
+|---|---|---|
+| Adapter supports tools, mocks declared | silent (today) | unchanged |
+| Adapter supports tools, no mocks declared | DEBUG log | unchanged |
+| Adapter has **none** of the three capabilities, run uses mocks/cassette/replay | **WARN log + stderr banner** | `Simulator.run` / `run_variants` entry |
+| Same as above + `MockSpec.strict=True` OR `--replay` flag set | **raise `UninterceptableAdapterError`** | same |
+
+The warning text:
+
+```
+⚠ Adapter 'http' cannot intercept tool calls — mocks/cassette declared
+  but none will be installed. The run is hitting live services.
+  See docs/SIMULATE.md#adapter-support-matrix.
+```
+
+The strict/replay error is fail-fast at the start of the run, before
+any live call has been made.
+
+### 3. Surface in the JSON / human output
+
+Extend `SimulationResult` (in `types.py`) with one field:
+
+```python
+adapter_capability: Dict[str, bool] = Field(default_factory=dict)
+```
+
+The `simulate` CLI prints it under the "Mocks applied:" section so
+users see the *capability*, not just the absence of matches:
+
+```
+▶ flight-search-sim  (seed=42, variants=1)
+  Mocks applied: none matched
+  Adapter capability: tools=✗ responses=✗ http=✗   ← new line, red when all-false
+  Variants:
+    · #0 branch=b0 $0.0000 0ms
+```
+
+### 4. CLI flag for opt-in to live runs
+
+Add `--allow-live` to `evalview simulate` to suppress the warning when
+the user has consciously decided that a partially-live run is fine.
+Without the flag, the warning fires every run; with it, the warning
+becomes a single-line `INFO`.
+
+## Implementation sketch
+
+Three small changes, all in already-touched files:
+
+1. **`evalview/core/simulation.py`** (~20 lines)
+   - Add `adapter_simulation_capability()` helper.
+   - Add `UninterceptableAdapterError` class.
+   - At the top of `Simulator.run` / `run_variants`, compute
+     capability; if all-false AND mocks/cassette/replay are in play,
+     either warn (lenient) or raise (strict/replay).
+   - Stamp capability into `SimulationResult` for downstream.
+
+2. **`evalview/core/types.py`** (~3 lines)
+   - Add `adapter_capability: Dict[str, bool]` to `SimulationResult`.
+
+3. **`evalview/commands/simulate_cmd.py`** (~10 lines)
+   - Add `--allow-live` flag.
+   - Render the capability line in `_format_human`.
+
+4. **`evalview/adapters/*`** (audit + tag, ~1 line per adapter)
+   - For each adapter, confirm whether `tool_executor` exists; if it
+     doesn't but the adapter could support `install_mock_interceptor`,
+     leave a TODO. (No code change today; just establishes ground
+     truth for the matrix.)
+
+## Tests
+
+- `test_simulation.py::test_warns_when_adapter_uninterceptable` —
+  fake adapter without `tool_executor`; assert WARN logged and
+  stderr banner present.
+- `test_simulation.py::test_raises_under_strict_when_uninterceptable`
+  — same fake adapter, `MockSpec(strict=True)`, assert
+  `UninterceptableAdapterError`.
+- `test_simulation.py::test_raises_when_replay_uninterceptable` —
+  pass a cassette to a non-tool-executor adapter, assert raise.
+- `test_simulation.py::test_allow_live_suppresses_warning` — pass
+  through CLI; assert `--allow-live` downgrades to INFO.
+- `test_simulation.py::test_capability_recorded_in_result` —
+  assert `SimulationResult.adapter_capability` reflects the truth
+  for both an interceptable and uninterceptable adapter.
+
+## Rollout
+
+- One PR, no migration. The warning is purely additive; the strict
+  raise only fires in modes (`strict=True`, `--replay`) where the
+  user has already opted into hermetic semantics — they would *want*
+  to be told the run is silently going live.
+- Update `docs/SIMULATE.md`'s adapter matrix to use the same
+  `tools/responses/http` rubric as the runtime check, so the doc and
+  the CLI never disagree.
+
+## Why not just refuse to run?
+
+Mixed live/mock runs are legitimately useful — e.g. `simulate` against
+a real LLM but with one flaky tool stubbed. The warning is the floor;
+strict mode (which the user opts into) is the ceiling. This matches
+the existing `MockSpec.strict` semantics and avoids breaking any
+working workflow.
+
+## Open questions
+
+1. Should the `record` flag also raise on uninterceptable adapters?
+   It would silently produce an empty cassette today, which is
+   confusing. Recommendation: yes, raise — same as `--replay`.
+2. Should the capability check distinguish "adapter has the attribute
+   but it's `None`" (Anthropic before init) from "adapter doesn't
+   support it"? Probably yes — `hasattr` returns true for both today.
+3. The `supports_http_mocks` flag is new and will be missing from
+   every adapter at first; default `False` is the safe answer but
+   means the HTTP-mock column is "✗" everywhere until adapters
+   explicitly opt in. That's fine — accurate is better than
+   optimistic.

--- a/evalview/commands/simulate_cmd.py
+++ b/evalview/commands/simulate_cmd.py
@@ -87,9 +87,9 @@ def _format_human(
 
     if adapter_capability:
         cap_str = (
-            f"tools={_capability_flag(adapter_capability.get('tools'))} "
-            f"responses={_capability_flag(adapter_capability.get('responses'))} "
-            f"http={_capability_flag(adapter_capability.get('http'))}"
+            f"tools={_capability_flag(bool(adapter_capability.get('tools')))} "
+            f"responses={_capability_flag(bool(adapter_capability.get('responses')))} "
+            f"http={_capability_flag(bool(adapter_capability.get('http')))}"
         )
         if not any(adapter_capability.values()):
             cap_str += "  ⚠ adapter has no interception seam — run is hitting live services"

--- a/evalview/commands/simulate_cmd.py
+++ b/evalview/commands/simulate_cmd.py
@@ -62,6 +62,10 @@ def _resolve_test_cases(
     return cases
 
 
+def _capability_flag(value: bool) -> str:
+    return "✓" if value else "✗"
+
+
 def _format_human(
     test_name: str,
     seed: int,
@@ -69,6 +73,7 @@ def _format_human(
     mocks_applied: List[dict],
     variant_outcomes: List[dict],
     branches: List[dict],
+    adapter_capability: Optional[dict] = None,
 ) -> str:
     """Readable terminal summary. JSON path skips this entirely."""
     lines: List[str] = []
@@ -79,6 +84,16 @@ def _format_human(
             lines.append(f"    · {m['kind']}:{m['matcher']} ×{m['count']}")
     else:
         lines.append("  Mocks applied: none matched")
+
+    if adapter_capability:
+        cap_str = (
+            f"tools={_capability_flag(adapter_capability.get('tools'))} "
+            f"responses={_capability_flag(adapter_capability.get('responses'))} "
+            f"http={_capability_flag(adapter_capability.get('http'))}"
+        )
+        if not any(adapter_capability.values()):
+            cap_str += "  ⚠ adapter has no interception seam — run is hitting live services"
+        lines.append(f"  Adapter capability: {cap_str}")
 
     lines.append("  Variants:")
     if variant_outcomes:
@@ -109,6 +124,7 @@ async def _run_one(
     *,
     record: bool = False,
     replay: bool = False,
+    allow_live: bool = False,
     cassette_dir: Path = DEFAULT_CASSETTE_DIR,
 ) -> dict:
     """Run a single test case and return a serializable summary dict."""
@@ -146,11 +162,18 @@ async def _run_one(
     sim = Simulator(adapter, spec)
     if variants > 1:
         traces, result = await sim.run_variants(
-            tc, variants=variants, replay_cassette=replay_cassette, record=record
+            tc,
+            variants=variants,
+            replay_cassette=replay_cassette,
+            record=record,
+            allow_live=allow_live,
         )
     else:
         _, result = await sim.run(
-            tc, replay_cassette=replay_cassette, record=record
+            tc,
+            replay_cassette=replay_cassette,
+            record=record,
+            allow_live=allow_live,
         )
         traces = []
 
@@ -202,6 +225,17 @@ async def _run_one(
     show_default=True,
     help="Override the directory used to find/store cassettes.",
 )
+@click.option(
+    "--allow-live",
+    is_flag=True,
+    default=False,
+    help=(
+        "Suppress the warning when the adapter has no interception seam. "
+        "By default an uninterceptable adapter logs a warning; with this "
+        "flag it logs INFO instead. Hermetic modes (--record, --replay, "
+        "or mocks.strict=true) still raise."
+    ),
+)
 @track_command("simulate")
 def simulate(
     test_path: str,
@@ -212,6 +246,7 @@ def simulate(
     record: bool,
     replay: bool,
     cassette_dir: str,
+    allow_live: bool,
 ) -> None:
     """Run tests hermetically against declared mocks.
 
@@ -245,7 +280,9 @@ def simulate(
         try:
             summary = asyncio.run(_run_one(
                 tc, config, variants, seed,
-                record=record, replay=replay, cassette_dir=cassette_dir_path,
+                record=record, replay=replay,
+                allow_live=allow_live,
+                cassette_dir=cassette_dir_path,
             ))
         except Exception as exc:
             summaries.append({
@@ -267,6 +304,7 @@ def simulate(
                     sim["mocks_applied"],
                     sim["variant_outcomes"],
                     sim["branches_explored"],
+                    adapter_capability=sim.get("adapter_capability"),
                 )
             )
             if summary.get("cassette"):

--- a/evalview/commands/simulate_cmd.py
+++ b/evalview/commands/simulate_cmd.py
@@ -24,6 +24,12 @@ from typing import List, Optional
 import click
 
 from evalview.core.adapter_factory import create_adapter_from_config
+from evalview.core.cassette import (
+    DEFAULT_CASSETTE_DIR,
+    cassette_path_for,
+    load_cassette,
+    save_cassette,
+)
 from evalview.core.config import EvalViewConfig
 from evalview.core.loader import TestCaseLoader
 from evalview.core.simulation import Simulator
@@ -100,6 +106,10 @@ async def _run_one(
     config: Optional[EvalViewConfig],
     variants: int,
     seed_override: Optional[int],
+    *,
+    record: bool = False,
+    replay: bool = False,
+    cassette_dir: Path = DEFAULT_CASSETTE_DIR,
 ) -> dict:
     """Run a single test case and return a serializable summary dict."""
     if tc.mocks is None:
@@ -123,18 +133,47 @@ async def _run_one(
     )
     adapter = create_adapter_from_config(run_config)
 
+    cassette_path = cassette_path_for(tc.name, cassette_dir)
+    replay_cassette = None
+    if replay:
+        if not cassette_path.exists():
+            raise click.ClickException(
+                f"--replay set but no cassette found at {cassette_path}. "
+                f"Run with --record first."
+            )
+        replay_cassette = load_cassette(cassette_path)
+
     sim = Simulator(adapter, spec)
     if variants > 1:
-        traces, result = await sim.run_variants(tc, variants=variants)
+        traces, result = await sim.run_variants(
+            tc, variants=variants, replay_cassette=replay_cassette, record=record
+        )
     else:
-        _, result = await sim.run(tc)
+        _, result = await sim.run(
+            tc, replay_cassette=replay_cassette, record=record
+        )
         traces = []
+
+    cassette_info: Optional[dict] = None
+    if record and result.recorded_cassette is not None:
+        save_cassette(result.recorded_cassette, cassette_path)
+        cassette_info = {
+            "path": str(cassette_path),
+            "interactions": len(result.recorded_cassette.interactions),
+        }
+    elif replay_cassette is not None:
+        cassette_info = {
+            "path": str(cassette_path),
+            "interactions": len(replay_cassette.interactions),
+            "mode": "replay",
+        }
 
     return {
         "test_name": tc.name,
         "run_type": "simulation",
         "simulation": result.model_dump(),
         "trace_count": len(traces) or 1,
+        "cassette": cassette_info,
     }
 
 
@@ -144,6 +183,25 @@ async def _run_one(
 @click.option("--seed", type=int, default=None, help="Override the seed declared in YAML.")
 @click.option("--variants", type=int, default=1, help="Run N deterministic replays (default: 1).")
 @click.option("--json", "json_output", is_flag=True, default=False, help="Emit JSON summary for CI.")
+@click.option(
+    "--record",
+    is_flag=True,
+    default=False,
+    help="Capture every real tool call into .evalview/cassettes/<test>.json for later replay.",
+)
+@click.option(
+    "--replay",
+    is_flag=True,
+    default=False,
+    help="Serve tool calls from the cassette at .evalview/cassettes/<test>.json (hermetic).",
+)
+@click.option(
+    "--cassette-dir",
+    type=click.Path(),
+    default=str(DEFAULT_CASSETTE_DIR),
+    show_default=True,
+    help="Override the directory used to find/store cassettes.",
+)
 @track_command("simulate")
 def simulate(
     test_path: str,
@@ -151,6 +209,9 @@ def simulate(
     seed: Optional[int],
     variants: int,
     json_output: bool,
+    record: bool,
+    replay: bool,
+    cassette_dir: str,
 ) -> None:
     """Run tests hermetically against declared mocks.
 
@@ -166,6 +227,9 @@ def simulate(
     """
     if variants < 1:
         raise click.ClickException("--variants must be >= 1")
+    if record and replay:
+        raise click.ClickException("--record and --replay are mutually exclusive.")
+    cassette_dir_path = Path(cassette_dir)
 
     cases = _resolve_test_cases(test_path, test_filter)
     if not cases:
@@ -179,7 +243,10 @@ def simulate(
     summaries: List[dict] = []
     for tc in cases:
         try:
-            summary = asyncio.run(_run_one(tc, config, variants, seed))
+            summary = asyncio.run(_run_one(
+                tc, config, variants, seed,
+                record=record, replay=replay, cassette_dir=cassette_dir_path,
+            ))
         except Exception as exc:
             summaries.append({
                 "test_name": tc.name,
@@ -202,6 +269,10 @@ def simulate(
                     sim["branches_explored"],
                 )
             )
+            if summary.get("cassette"):
+                ci = summary["cassette"]
+                verb = "Replayed" if ci.get("mode") == "replay" else "Recorded"
+                click.echo(f"  {verb} cassette: {ci['path']} ({ci['interactions']} interactions)")
 
     if json_output:
         click.echo(json.dumps({"results": summaries}, indent=2))

--- a/evalview/core/cassette.py
+++ b/evalview/core/cassette.py
@@ -1,0 +1,205 @@
+"""VCR-style record/replay cassettes for hermetic tool replay.
+
+The :mod:`simulation` engine already exposes a tool-mock seam via the
+``tool_executor`` adapter attribute. Cassettes turn that into a
+record-once / replay-forever workflow:
+
+* :class:`RecordingToolExecutor` wraps a real ``tool_executor`` and
+  captures every ``(tool, params) -> result`` (or error) into an
+  in-memory :class:`Cassette`. The orchestrator persists it to
+  ``.evalview/cassettes/<test-name>.json`` after the run.
+* :class:`ReplayToolExecutor` serves calls from a previously recorded
+  cassette, consuming entries per-tool in declaration order. Mismatches
+  raise :class:`CassetteMismatchError` under ``strict=True``; under
+  the default lenient mode they fall through to the wrapped real
+  executor (or return ``None`` if there is none).
+
+The matching strategy is **per-tool sequential**: calls to a given
+tool name consume that tool's recorded entries in order. This is
+robust to inter-tool ordering drift (the agent may legitimately call
+``lookup`` before or after ``check_policy`` on different runs) while
+still pinning intra-tool state (a tool called twice with the same
+params can return different values).
+
+Scope of the v1 cassette: tool calls only. LLM-response and HTTP
+cassettes follow the same shape but require adapter opt-in via
+``install_mock_interceptor`` and are tracked separately under the
+``response`` / ``http`` interaction kinds for future expansion. The
+JSON schema reserves the fields today so cassettes recorded now
+remain forward-compatible.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from evalview.core.types import Cassette, Interaction
+
+logger = logging.getLogger(__name__)
+
+
+CASSETTE_FORMAT_VERSION = 1
+DEFAULT_CASSETTE_DIR = Path(".evalview/cassettes")
+
+
+ToolExecutor = Callable[[str, Dict[str, Any]], Any]
+
+
+class CassetteError(RuntimeError):
+    """Base class for cassette errors."""
+
+
+class CassetteMismatchError(CassetteError):
+    """Raised when a strict replay encounters an unmatched call."""
+
+
+def cassette_path_for(test_name: str, root: Path = DEFAULT_CASSETTE_DIR) -> Path:
+    """Default on-disk location for a test's cassette.
+
+    Slashes in the name are replaced with ``__`` so multi-segment names
+    (e.g. ``billing/refund``) stay flat under the cassette dir.
+    """
+    safe = test_name.replace("/", "__").replace("\\", "__")
+    return root / f"{safe}.json"
+
+
+def save_cassette(cassette: Cassette, path: Path) -> None:
+    """Write a cassette to disk, creating parent directories as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(cassette.model_dump_json(indent=2))
+
+
+def load_cassette(path: Path) -> Cassette:
+    """Load a cassette JSON, validating the schema."""
+    raw = json.loads(path.read_text())
+    if raw.get("version", 0) > CASSETTE_FORMAT_VERSION:
+        raise CassetteError(
+            f"Cassette {path} was recorded with format v{raw['version']} "
+            f"but this evalview only understands up to v{CASSETTE_FORMAT_VERSION}. "
+            "Upgrade evalview or re-record."
+        )
+    return Cassette.model_validate(raw)
+
+
+@dataclass
+class RecordingToolExecutor:
+    """Wraps a real executor and records every call.
+
+    On each call, the wrapped executor runs first; the result (or the
+    error it raised) is then appended to ``interactions``. Errors are
+    captured and re-raised so the agent sees the same behavior it would
+    see live — recording is transparent.
+    """
+
+    real: ToolExecutor
+    interactions: List[Interaction] = field(default_factory=list)
+
+    def __call__(self, tool_name: str, params: Dict[str, Any]) -> Any:
+        try:
+            result = self.real(tool_name, params)
+        except Exception as exc:
+            self.interactions.append(Interaction(
+                kind="tool",
+                tool=tool_name,
+                params=dict(params or {}),
+                returns=None,
+                error=f"{type(exc).__name__}: {exc}",
+            ))
+            raise
+        self.interactions.append(Interaction(
+            kind="tool",
+            tool=tool_name,
+            params=dict(params or {}),
+            returns=result,
+            error=None,
+        ))
+        return result
+
+
+class ReplayToolExecutor:
+    """Serves tool calls from a cassette, consuming per-tool in order.
+
+    Per-tool sequential matching: each tool name has its own queue of
+    recorded interactions. Successive calls to the same tool consume
+    its queue in declaration order, which keeps replay deterministic
+    even when the agent shuffles inter-tool ordering between runs.
+
+    Behavior on a miss:
+    - ``strict=True``: raise :class:`CassetteMismatchError`.
+    - ``strict=False``: fall through to ``real`` if provided; else
+      return ``None`` and log at DEBUG.
+    """
+
+    def __init__(
+        self,
+        cassette: Cassette,
+        real: Optional[ToolExecutor] = None,
+        strict: bool = False,
+    ) -> None:
+        self._cassette = cassette
+        self._real = real
+        self._strict = strict
+        self._queues: Dict[str, List[Interaction]] = {}
+        for entry in cassette.interactions:
+            if entry.kind != "tool" or entry.tool is None:
+                continue
+            self._queues.setdefault(entry.tool, []).append(entry)
+        self.replays: List[Interaction] = []
+
+    def __call__(self, tool_name: str, params: Dict[str, Any]) -> Any:
+        queue = self._queues.get(tool_name)
+        if queue:
+            entry = queue.pop(0)
+            self.replays.append(entry)
+            if entry.error:
+                raise RuntimeError(entry.error)
+            return entry.returns
+
+        if self._strict:
+            raise CassetteMismatchError(
+                f"Cassette has no remaining recording for tool '{tool_name}' "
+                f"(strict mode). Re-record with --record or relax to lenient."
+            )
+        if self._real is not None:
+            logger.debug(
+                "Cassette miss for '%s'; falling through to real executor.",
+                tool_name,
+            )
+            return self._real(tool_name, params)
+        logger.debug("Cassette miss for '%s' with no real executor; returning None.", tool_name)
+        return None
+
+    def remaining(self) -> Dict[str, int]:
+        """Per-tool counts of unused recordings — surfaces over/under-replay."""
+        return {tool: len(q) for tool, q in self._queues.items() if q}
+
+
+def new_cassette(test_name: str, adapter: Optional[str] = None) -> Cassette:
+    """Build an empty cassette stamped with the current UTC time."""
+    return Cassette(
+        test_name=test_name,
+        recorded_at=datetime.now(timezone.utc).isoformat(),
+        adapter=adapter,
+        interactions=[],
+    )
+
+
+__all__ = [
+    "CASSETTE_FORMAT_VERSION",
+    "DEFAULT_CASSETTE_DIR",
+    "Cassette",
+    "CassetteError",
+    "CassetteMismatchError",
+    "Interaction",
+    "RecordingToolExecutor",
+    "ReplayToolExecutor",
+    "cassette_path_for",
+    "load_cassette",
+    "new_cassette",
+    "save_cassette",
+]

--- a/evalview/core/cassette.py
+++ b/evalview/core/cassette.py
@@ -33,10 +33,11 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Deque, Dict, List, Optional
 
 from evalview.core.types import Cassette, Interaction
 
@@ -144,17 +145,19 @@ class ReplayToolExecutor:
         self._cassette = cassette
         self._real = real
         self._strict = strict
-        self._queues: Dict[str, List[Interaction]] = {}
+        # Deques give O(1) popleft; lists are O(n) on pop(0), which
+        # would degrade replay of long recordings.
+        self._queues: Dict[str, Deque[Interaction]] = {}
         for entry in cassette.interactions:
             if entry.kind != "tool" or entry.tool is None:
                 continue
-            self._queues.setdefault(entry.tool, []).append(entry)
+            self._queues.setdefault(entry.tool, deque()).append(entry)
         self.replays: List[Interaction] = []
 
     def __call__(self, tool_name: str, params: Dict[str, Any]) -> Any:
         queue = self._queues.get(tool_name)
         if queue:
-            entry = queue.pop(0)
+            entry = queue.popleft()
             self.replays.append(entry)
             if entry.error:
                 raise RuntimeError(entry.error)

--- a/evalview/core/simulation.py
+++ b/evalview/core/simulation.py
@@ -35,6 +35,12 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from evalview.adapters.base import AgentAdapter
+from evalview.core.cassette import (
+    Cassette,
+    RecordingToolExecutor,
+    ReplayToolExecutor,
+    new_cassette,
+)
 from evalview.core.types import (
     AppliedMock,
     BranchExploration,
@@ -184,6 +190,56 @@ class Simulator:
         return hit
 
     # ------------------------------------------------------------------
+    # Internal: build the per-run executor stack
+    # ------------------------------------------------------------------
+
+    def _build_stack(
+        self,
+        rng: random.Random,
+        counter: _MockHitCounter,
+        replay_cassette: Optional[Cassette],
+        record_into: Optional[List["RecordingToolExecutor"]],
+    ) -> ToolExecutor:
+        """Layer the executor stack: mocks → recorder → (replay | real).
+
+        Order rationale:
+        - Declarative mocks always win first so users can override a
+          single cassette entry without re-recording the whole run.
+        - The recorder sits *below* mocks so synthetic mock results
+          never leak into a fresh cassette — only what the real layer
+          (or replay layer) actually returned.
+        - Replay, when present, replaces the real executor entirely;
+          it falls through to the real executor on a miss only when
+          ``MockSpec.strict`` is false.
+        """
+        real_executor = getattr(self._adapter, "tool_executor", None)
+
+        underlying: Optional[ToolExecutor]
+        if replay_cassette is not None:
+            underlying = ReplayToolExecutor(
+                replay_cassette,
+                real=real_executor,
+                strict=self._spec.strict,
+            )
+        else:
+            underlying = real_executor
+
+        if record_into is not None and underlying is not None:
+            recorder = RecordingToolExecutor(real=underlying)
+            record_into.append(recorder)
+            underlying = recorder
+
+        # When a replay cassette is installed, hermetic-strict semantics
+        # belong to the cassette layer, not the mock layer — otherwise
+        # the mock layer rejects any call that isn't explicitly mocked,
+        # never giving the cassette a chance to serve it.
+        mock_spec = self._spec
+        if replay_cassette is not None and self._spec.strict:
+            mock_spec = self._spec.model_copy(update={"strict": False})
+
+        return MockedToolExecutor(mock_spec, underlying, counter, rng)
+
+    # ------------------------------------------------------------------
     # Run entry points
     # ------------------------------------------------------------------
 
@@ -191,6 +247,9 @@ class Simulator:
         self,
         test_case: TestCase,
         seed_override: Optional[int] = None,
+        *,
+        replay_cassette: Optional[Cassette] = None,
+        record: bool = False,
     ) -> Tuple[ExecutionTrace, SimulationResult]:
         """Execute one simulated run and return (trace, SimulationResult).
 
@@ -199,13 +258,20 @@ class Simulator:
         convention). The original executor is restored after
         execution. Unmatched calls fall through unless ``spec.strict``
         is true.
+
+        When ``replay_cassette`` is provided, recorded tool results
+        serve calls in their place (per-tool sequential matching).
+        When ``record`` is true, the run captures every real tool call
+        into ``SimulationResult.recorded_cassette`` so the caller can
+        persist it with :func:`evalview.core.cassette.save_cassette`.
         """
         counter = _MockHitCounter()
         seed = self._spec.seed if seed_override is None else seed_override
         rng = random.Random(seed)
 
         real_executor = getattr(self._adapter, "tool_executor", None)
-        mocked = MockedToolExecutor(self._spec, real_executor, counter, rng)
+        recorders: Optional[List[RecordingToolExecutor]] = [] if record else None
+        mocked = self._build_stack(rng, counter, replay_cassette, recorders)
 
         # Install the mock layer via the adapter attribute rather than
         # the context dict — HTTP/streaming adapters JSON-serialize
@@ -235,6 +301,11 @@ class Simulator:
         # branch so the cloud UI always has something to render, even
         # when the agent only took the happy path.
         path = [f"{s.step_id}:{s.tool_name}" for s in trace.steps]
+        recorded_cassette: Optional[Cassette] = None
+        if recorders:
+            recorded_cassette = new_cassette(test_case.name, adapter=self._adapter.name)
+            for r in recorders:
+                recorded_cassette.interactions.extend(r.interactions)
         result = SimulationResult(
             seed=seed,
             mocks_applied=counter.to_applied(),
@@ -248,6 +319,7 @@ class Simulator:
                 )
             ],
             variant_outcomes=[],
+            recorded_cassette=recorded_cassette,
         )
         return trace, result
 
@@ -255,6 +327,9 @@ class Simulator:
         self,
         test_case: TestCase,
         variants: int,
+        *,
+        replay_cassette: Optional[Cassette] = None,
+        record: bool = False,
     ) -> Tuple[List[ExecutionTrace], SimulationResult]:
         """Fan out ``variants`` deterministic replays and aggregate.
 
@@ -263,6 +338,12 @@ class Simulator:
         the final output and cost/latency so cloud can render a pass/
         fail matrix. Scoring is left to the evaluator downstream —
         the simulator only reports raw outcomes.
+
+        ``replay_cassette`` and ``record`` behave the same as in
+        :meth:`run`. When recording, the cassette captures the
+        interactions from the *first* variant only — additional
+        variants would overwrite each other and reproducibility is
+        defined per-(test, seed) pair.
         """
         if variants < 1:
             raise ValueError("variants must be >= 1")
@@ -271,13 +352,17 @@ class Simulator:
         branches: List[BranchExploration] = []
         outcomes: List[VariantOutcome] = []
         combined_counter = _MockHitCounter()
+        recorded_cassette: Optional[Cassette] = None
 
         for i in range(variants):
             counter = _MockHitCounter()
             seed = (self._spec.seed or 0) + i
             rng = random.Random(seed)
             real_executor = getattr(self._adapter, "tool_executor", None)
-            mocked = MockedToolExecutor(self._spec, real_executor, counter, rng)
+            recorders: Optional[List[RecordingToolExecutor]] = (
+                [] if (record and i == 0) else None
+            )
+            mocked = self._build_stack(rng, counter, replay_cassette, recorders)
 
             context: Dict[str, Any] = dict(test_case.input.context or {})
             installer = getattr(self._adapter, "install_mock_interceptor", None)
@@ -301,6 +386,11 @@ class Simulator:
                 combined_counter.hits[(kind, matcher)] = (
                     combined_counter.hits.get((kind, matcher), 0) + count
                 )
+
+            if recorders:
+                recorded_cassette = new_cassette(test_case.name, adapter=self._adapter.name)
+                for r in recorders:
+                    recorded_cassette.interactions.extend(r.interactions)
 
             branch_id = f"b{i}"
             path = [f"{s.step_id}:{s.tool_name}" for s in trace.steps]
@@ -329,6 +419,7 @@ class Simulator:
             mocks_applied=combined_counter.to_applied(),
             branches_explored=branches,
             variant_outcomes=outcomes,
+            recorded_cassette=recorded_cassette,
         )
         return traces, result
 

--- a/evalview/core/simulation.py
+++ b/evalview/core/simulation.py
@@ -63,6 +63,40 @@ class UnmatchedMockError(RuntimeError):
     """Raised when ``MockSpec.strict`` is true and a call has no mock."""
 
 
+class UninterceptableAdapterError(RuntimeError):
+    """Raised when a hermetic-required run targets an adapter that has no
+    interception seam (no ``tool_executor``, no ``install_mock_interceptor``).
+
+    Without one of those hooks, mocks/cassettes/replay can't actually
+    install — the run would silently hit live services. Failing fast
+    is the only honest answer when the user has explicitly opted into
+    hermetic semantics via ``--record``, ``--replay``, or
+    ``MockSpec.strict=True``.
+    """
+
+
+def adapter_simulation_capability(adapter: AgentAdapter) -> Dict[str, bool]:
+    """Report which simulation layers an adapter can actually intercept.
+
+    Returns a dict with three booleans:
+        tools     — has a ``tool_executor`` attribute the simulator can swap.
+        responses — has ``install_mock_interceptor``, so it can pull
+                    LLM-response mocks from the simulator.
+        http      — declares ``supports_http_mocks=True`` (opt-in flag
+                    adapters set when they wire ``http_mock_for`` into
+                    their transport).
+
+    The check is intentionally cheap and side-effect-free so callers
+    can run it before every ``Simulator.run`` to decide whether to
+    warn / raise / proceed.
+    """
+    return {
+        "tools": hasattr(adapter, "tool_executor"),
+        "responses": callable(getattr(adapter, "install_mock_interceptor", None)),
+        "http": bool(getattr(adapter, "supports_http_mocks", False)),
+    }
+
+
 def _params_match(call_params: Dict[str, Any], match_params: Optional[Dict[str, Any]]) -> bool:
     """Subset-match: every key/value in ``match_params`` must equal the call."""
     if not match_params:
@@ -176,6 +210,52 @@ class Simulator:
         self._spec = spec
 
     # ------------------------------------------------------------------
+    # Internal: capability gate
+    # ------------------------------------------------------------------
+
+    def _check_capability(
+        self,
+        *,
+        replay: bool,
+        record: bool,
+        allow_live: bool,
+    ) -> Dict[str, bool]:
+        """Detect uninterceptable adapters before the run starts.
+
+        Three escalation tiers:
+          - Adapter has any interception seam → silent (capability is
+            still recorded on the result for transparency).
+          - No seam, but the user did not opt into hermetic semantics
+            (no record/replay, ``strict=False``) → log a warning and
+            proceed unless ``allow_live`` is set, in which case the
+            warning drops to INFO.
+          - No seam AND the user opted in (``record``, ``replay``, or
+            ``MockSpec.strict``) → raise
+            :class:`UninterceptableAdapterError` so the run fails fast
+            instead of silently going live.
+        """
+        cap = adapter_simulation_capability(self._adapter)
+        if any(cap.values()):
+            return cap
+
+        hermetic_required = record or replay or self._spec.strict
+        adapter_name = getattr(self._adapter, "name", type(self._adapter).__name__)
+        msg = (
+            f"Adapter '{adapter_name}' has no tool interception seam "
+            "(no `tool_executor`, no `install_mock_interceptor`, no "
+            "`supports_http_mocks`). Mocks/cassette/replay cannot be "
+            "installed — the run would hit live services. "
+            "See docs/SIMULATE.md#adapter-support-matrix."
+        )
+        if hermetic_required:
+            raise UninterceptableAdapterError(msg)
+        if allow_live:
+            logger.info(msg)
+        else:
+            logger.warning(msg)
+        return cap
+
+    # ------------------------------------------------------------------
     # Public helpers the CLI / adapters can import
     # ------------------------------------------------------------------
 
@@ -250,6 +330,7 @@ class Simulator:
         *,
         replay_cassette: Optional[Cassette] = None,
         record: bool = False,
+        allow_live: bool = False,
     ) -> Tuple[ExecutionTrace, SimulationResult]:
         """Execute one simulated run and return (trace, SimulationResult).
 
@@ -264,7 +345,19 @@ class Simulator:
         When ``record`` is true, the run captures every real tool call
         into ``SimulationResult.recorded_cassette`` so the caller can
         persist it with :func:`evalview.core.cassette.save_cassette`.
+
+        Raises :class:`UninterceptableAdapterError` when the run requires
+        hermetic semantics (``record``, ``replay_cassette``, or
+        ``MockSpec.strict``) but the adapter exposes no interception
+        seam. Otherwise an uninterceptable adapter logs a warning
+        (downgraded to INFO when ``allow_live=True``) and proceeds.
         """
+        capability = self._check_capability(
+            replay=replay_cassette is not None,
+            record=record,
+            allow_live=allow_live,
+        )
+
         counter = _MockHitCounter()
         seed = self._spec.seed if seed_override is None else seed_override
         rng = random.Random(seed)
@@ -320,6 +413,7 @@ class Simulator:
             ],
             variant_outcomes=[],
             recorded_cassette=recorded_cassette,
+            adapter_capability=capability,
         )
         return trace, result
 
@@ -330,6 +424,7 @@ class Simulator:
         *,
         replay_cassette: Optional[Cassette] = None,
         record: bool = False,
+        allow_live: bool = False,
     ) -> Tuple[List[ExecutionTrace], SimulationResult]:
         """Fan out ``variants`` deterministic replays and aggregate.
 
@@ -348,31 +443,40 @@ class Simulator:
         if variants < 1:
             raise ValueError("variants must be >= 1")
 
+        capability = self._check_capability(
+            replay=replay_cassette is not None,
+            record=record,
+            allow_live=allow_live,
+        )
+
         traces: List[ExecutionTrace] = []
         branches: List[BranchExploration] = []
         outcomes: List[VariantOutcome] = []
         combined_counter = _MockHitCounter()
         recorded_cassette: Optional[Cassette] = None
 
+        # Adapter is the same object across variants — resolve its
+        # interception attributes once.
+        real_executor = getattr(self._adapter, "tool_executor", None)
+        installer = getattr(self._adapter, "install_mock_interceptor", None)
+        had_attr = hasattr(self._adapter, "tool_executor")
+
         for i in range(variants):
             counter = _MockHitCounter()
             seed = (self._spec.seed or 0) + i
             rng = random.Random(seed)
-            real_executor = getattr(self._adapter, "tool_executor", None)
             recorders: Optional[List[RecordingToolExecutor]] = (
                 [] if (record and i == 0) else None
             )
             mocked = self._build_stack(rng, counter, replay_cassette, recorders)
 
             context: Dict[str, Any] = dict(test_case.input.context or {})
-            installer = getattr(self._adapter, "install_mock_interceptor", None)
             if callable(installer):
                 try:
                     installer(self)
                 except Exception as exc:  # pragma: no cover
                     logger.warning("install_mock_interceptor raised: %s", exc)
 
-            had_attr = hasattr(self._adapter, "tool_executor")
             if had_attr:
                 setattr(self._adapter, "tool_executor", mocked)
             try:
@@ -420,8 +524,15 @@ class Simulator:
             branches_explored=branches,
             variant_outcomes=outcomes,
             recorded_cassette=recorded_cassette,
+            adapter_capability=capability,
         )
         return traces, result
 
 
-__all__ = ["Simulator", "MockedToolExecutor", "UnmatchedMockError"]
+__all__ = [
+    "MockedToolExecutor",
+    "Simulator",
+    "UninterceptableAdapterError",
+    "UnmatchedMockError",
+    "adapter_simulation_capability",
+]

--- a/evalview/core/types.py
+++ b/evalview/core/types.py
@@ -579,6 +579,14 @@ class SimulationResult(BaseModel):
     branches_explored: List[BranchExploration] = Field(default_factory=list)
     variant_outcomes: List[VariantOutcome] = Field(default_factory=list)
     recorded_cassette: Optional[Cassette] = Field(default=None, exclude=True)
+    adapter_capability: Dict[str, bool] = Field(
+        default_factory=dict,
+        description=(
+            "Per-layer interception ability detected at run start: "
+            "tools / responses / http. All-false means the run hit "
+            "live services regardless of declared mocks."
+        ),
+    )
 
 
 # --- Execution Trace Types ---

--- a/evalview/core/types.py
+++ b/evalview/core/types.py
@@ -536,6 +536,31 @@ class VariantOutcome(BaseModel):
     notes: Optional[str] = None
 
 
+class Interaction(BaseModel):
+    """One recorded tool/LLM/HTTP call inside a :class:`Cassette`.
+
+    Only ``kind="tool"`` is consumed by the v1 replay path; the
+    ``response``/``http`` kinds are reserved so cassettes round-trip
+    forward when adapter-side hooks land for those layers.
+    """
+
+    kind: str = Field(default="tool", description="One of tool|response|http.")
+    tool: Optional[str] = None
+    params: Dict[str, Any] = Field(default_factory=dict)
+    returns: Any = None
+    error: Optional[str] = None
+
+
+class Cassette(BaseModel):
+    """A recorded set of interactions for hermetic replay of one test."""
+
+    version: int = Field(default=1)
+    test_name: str
+    recorded_at: str
+    adapter: Optional[str] = None
+    interactions: List[Interaction] = Field(default_factory=list)
+
+
 class SimulationResult(BaseModel):
     """Payload attached to an EvaluationResult when run under ``evalview simulate``.
 
@@ -543,12 +568,17 @@ class SimulationResult(BaseModel):
     existing GateResult fields. Cloud stores ``mocks_applied`` and
     ``branches_explored`` in the ``simulations`` table and renders them
     on the simulation tab; it never runs simulations itself.
+
+    ``recorded_cassette`` is populated only when the run was started
+    with ``record=True``; it is not persisted to cloud (the CLI
+    writes it to ``.evalview/cassettes/<test>.json`` instead).
     """
 
     seed: int = 0
     mocks_applied: List[AppliedMock] = Field(default_factory=list)
     branches_explored: List[BranchExploration] = Field(default_factory=list)
     variant_outcomes: List[VariantOutcome] = Field(default_factory=list)
+    recorded_cassette: Optional[Cassette] = Field(default=None, exclude=True)
 
 
 # --- Execution Trace Types ---

--- a/examples/simulation/README.md
+++ b/examples/simulation/README.md
@@ -1,16 +1,34 @@
 # Simulation examples
 
 Worked YAML files demonstrating `evalview simulate` — hermetic runs
-against declared mocks for tool calls, LLM responses, and HTTP.
+against declared mocks (or recorded cassettes) for tool calls, LLM
+responses, and HTTP.
 
 | File | What it shows |
 |---|---|
-| `flight-booking.yaml` | Tool mocks with subset param matching, a deliberate error-path mock, and expected-behavior assertions that fail if the agent picks the wrong flight. |
+| `flight-booking.yaml` | Declarative `mocks:` block with subset param matching, a deliberate error-path mock, and expected-behavior assertions that fail if the agent picks the wrong flight. |
+| `order-lookup-replay.yaml` + `cassettes/order-lookup-replay.json` | The cassette workflow: no `mocks:` block in the YAML, hermetic replay served entirely from a pre-recorded JSON cassette. |
 
-Run all examples:
+## Cassette walkthrough
+
+Cassettes capture real tool calls once and replay them deterministically
+forever — no live services in CI.
 
 ```bash
-evalview simulate examples/simulation/ --variants 3
+# Replay hermetically using the bundled cassette:
+evalview simulate examples/simulation/order-lookup-replay.yaml \
+  --replay --cassette-dir examples/simulation/cassettes
+
+# Re-record after the real backend changes (requires API keys):
+evalview simulate examples/simulation/order-lookup-replay.yaml \
+  --record --cassette-dir examples/simulation/cassettes
 ```
+
+The cassette format is documented in
+[`docs/SIMULATE.md`](../../docs/SIMULATE.md#record--replay-cassettes).
+Per-tool sequential matching keeps replay robust even when the agent
+reorders calls between runs; declarative `mocks:` (if present) take
+precedence so a single recording can be overridden without
+re-recording the whole run.
 
 See `docs/SIMULATE.md` for the full YAML schema and CLI reference.

--- a/examples/simulation/cassettes/order-lookup-replay.json
+++ b/examples/simulation/cassettes/order-lookup-replay.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "test_name": "order-lookup-replay",
+  "recorded_at": "2026-05-04T12:00:00+00:00",
+  "adapter": "anthropic",
+  "interactions": [
+    {
+      "kind": "tool",
+      "tool": "lookup_order",
+      "params": { "order_id": 4812 },
+      "returns": {
+        "id": 4812,
+        "customer": "alice@example.com",
+        "total": 99.0,
+        "placed_at": "2026-05-01T09:14:00Z"
+      },
+      "error": null
+    },
+    {
+      "kind": "tool",
+      "tool": "check_shipment",
+      "params": { "order_id": 4812 },
+      "returns": {
+        "status": "shipped",
+        "carrier": "UPS",
+        "tracking": "1Z999AA10123456784",
+        "eta": "2026-05-06"
+      },
+      "error": null
+    }
+  ]
+}

--- a/examples/simulation/order-lookup-replay.yaml
+++ b/examples/simulation/order-lookup-replay.yaml
@@ -1,0 +1,47 @@
+# Example: replay an order-lookup agent from a pre-recorded cassette.
+#
+# This test deliberately has no `mocks:` block — the hermetic replay
+# is provided by a cassette in cassettes/order-lookup-replay.json,
+# captured against a real backend on a previous run.
+#
+# Run hermetically:
+#   evalview simulate examples/simulation/order-lookup-replay.yaml \
+#     --replay --cassette-dir examples/simulation/cassettes
+#
+# Re-record (e.g. after the real backend changes):
+#   evalview simulate examples/simulation/order-lookup-replay.yaml \
+#     --record --cassette-dir examples/simulation/cassettes
+
+name: order-lookup-replay
+description: Look up an order and summarize its status using a recorded cassette.
+
+adapter: anthropic
+endpoint: claude-sonnet-4-5-20250929
+
+input:
+  query: What's the status of order 4812?
+
+expected:
+  tools: [lookup_order, check_shipment]
+  output:
+    contains: ["4812", "shipped"]
+    not_contains: [error]
+
+thresholds:
+  min_score: 70
+
+tools:
+  - name: lookup_order
+    description: Retrieve order details by id.
+    input_schema:
+      type: object
+      properties:
+        order_id: { type: integer }
+      required: [order_id]
+  - name: check_shipment
+    description: Get the latest shipment status for an order.
+    input_schema:
+      type: object
+      properties:
+        order_id: { type: integer }
+      required: [order_id]

--- a/tests/test_cassette.py
+++ b/tests/test_cassette.py
@@ -1,0 +1,364 @@
+"""Tests for record/replay cassettes (`evalview/core/cassette.py`).
+
+Covers the three cases that matter for "is this actually hermetic?":
+
+1. **Recording is transparent** — wrapping a real executor doesn't
+   change what the agent sees, but every call lands in the cassette.
+2. **Round-trip equivalence** — a recorded cassette, replayed, returns
+   the same values without ever invoking the real executor.
+3. **Strict semantics** — extra/missing calls behave correctly under
+   both lenient and strict modes; per-tool sequential matching is
+   robust to inter-tool ordering drift.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from evalview.adapters.base import AgentAdapter
+from evalview.core.cassette import (
+    CASSETTE_FORMAT_VERSION,
+    CassetteError,
+    CassetteMismatchError,
+    RecordingToolExecutor,
+    ReplayToolExecutor,
+    cassette_path_for,
+    load_cassette,
+    new_cassette,
+    save_cassette,
+)
+from evalview.core.simulation import Simulator
+from evalview.core.types import (
+    Cassette,
+    ExecutionMetrics,
+    ExecutionTrace,
+    ExpectedBehavior,
+    Interaction,
+    MockSpec,
+    StepMetrics,
+    StepTrace,
+    TestCase,
+    TestInput,
+    Thresholds,
+    ToolMock,
+)
+
+
+class _ScriptedAdapter(AgentAdapter):
+    """Adapter that walks a fixed plan, calling tool_executor for each step."""
+
+    def __init__(self, plan: List[Dict[str, Any]]) -> None:
+        self._plan = plan
+        self.tool_executor = None
+
+    @property
+    def name(self) -> str:
+        return "scripted"
+
+    async def execute(self, query: str, context: Optional[Dict[str, Any]] = None) -> ExecutionTrace:
+        executor = self.tool_executor
+        assert executor is not None
+        steps: List[StepTrace] = []
+        outputs: List[str] = []
+        for i, call in enumerate(self._plan):
+            result = executor(call["tool"], call["params"])
+            outputs.append(str(result))
+            steps.append(StepTrace(
+                step_id=f"step-{i}",
+                step_name=call["tool"],
+                tool_name=call["tool"],
+                parameters=call["params"],
+                output=result,
+                success=True,
+                metrics=StepMetrics(latency=1.0, cost=0.0),
+            ))
+        return ExecutionTrace(
+            session_id="t",
+            start_time=datetime(2026, 5, 4, 10, 0, 0),
+            end_time=datetime(2026, 5, 4, 10, 0, 1),
+            steps=steps,
+            final_output=" | ".join(outputs),
+            metrics=ExecutionMetrics(total_cost=0.0, total_latency=1.0),
+        )
+
+
+def _case(name: str = "t", mocks: Optional[MockSpec] = None) -> TestCase:
+    return TestCase(
+        name=name,
+        input=TestInput(query="q"),
+        expected=ExpectedBehavior(),
+        thresholds=Thresholds(min_score=0),
+        mocks=mocks,
+    )
+
+
+# ============================================================================
+# RecordingToolExecutor — transparent capture
+# ============================================================================
+
+
+class TestRecordingToolExecutor:
+    def test_records_each_call_with_result(self):
+        def real(name, params):
+            return {"echo": name, "p": params}
+
+        rec = RecordingToolExecutor(real=real)
+        assert rec("search", {"q": "paris"}) == {"echo": "search", "p": {"q": "paris"}}
+        assert rec("lookup", {"id": 1}) == {"echo": "lookup", "p": {"id": 1}}
+
+        assert [i.tool for i in rec.interactions] == ["search", "lookup"]
+        assert rec.interactions[0].returns == {"echo": "search", "p": {"q": "paris"}}
+        assert rec.interactions[0].error is None
+
+    def test_records_errors_then_reraises(self):
+        def real(name, params):
+            raise ValueError("upstream boom")
+
+        rec = RecordingToolExecutor(real=real)
+        with pytest.raises(ValueError, match="upstream boom"):
+            rec("flaky", {})
+        assert len(rec.interactions) == 1
+        assert rec.interactions[0].error == "ValueError: upstream boom"
+        assert rec.interactions[0].returns is None
+
+    def test_params_are_copied_not_aliased(self):
+        """Mutating the params dict after recording must not alter the cassette."""
+        def real(name, params):
+            return None
+
+        rec = RecordingToolExecutor(real=real)
+        params = {"q": "v1"}
+        rec("search", params)
+        params["q"] = "v2"
+        assert rec.interactions[0].params == {"q": "v1"}
+
+
+# ============================================================================
+# ReplayToolExecutor — hermetic playback
+# ============================================================================
+
+
+class TestReplayToolExecutor:
+    def _cassette(self, *interactions: Interaction) -> Cassette:
+        return Cassette(
+            test_name="t",
+            recorded_at="2026-05-04T00:00:00Z",
+            interactions=list(interactions),
+        )
+
+    def test_serves_calls_in_recorded_order_per_tool(self):
+        cas = self._cassette(
+            Interaction(tool="search", params={}, returns="r1"),
+            Interaction(tool="search", params={}, returns="r2"),
+        )
+        rep = ReplayToolExecutor(cas)
+        assert rep("search", {}) == "r1"
+        assert rep("search", {}) == "r2"
+
+    def test_intertool_order_does_not_matter(self):
+        """The agent may reorder lookup vs check_policy between runs.
+
+        Per-tool sequential matching keeps replay deterministic anyway:
+        each tool name has its own queue, so calls consume independently.
+        """
+        cas = self._cassette(
+            Interaction(tool="lookup", params={}, returns="L1"),
+            Interaction(tool="check_policy", params={}, returns="P1"),
+            Interaction(tool="lookup", params={}, returns="L2"),
+        )
+        rep = ReplayToolExecutor(cas)
+        assert rep("check_policy", {}) == "P1"
+        assert rep("lookup", {}) == "L1"
+        assert rep("lookup", {}) == "L2"
+
+    def test_replays_recorded_errors(self):
+        cas = self._cassette(
+            Interaction(tool="flaky", error="RuntimeError: boom"),
+        )
+        rep = ReplayToolExecutor(cas)
+        with pytest.raises(RuntimeError, match="RuntimeError: boom"):
+            rep("flaky", {})
+
+    def test_strict_raises_on_unmatched(self):
+        cas = self._cassette(Interaction(tool="search", returns="r"))
+        rep = ReplayToolExecutor(cas, strict=True)
+        with pytest.raises(CassetteMismatchError):
+            rep("unrecorded", {})
+
+    def test_lenient_falls_through_to_real(self):
+        cas = self._cassette(Interaction(tool="search", returns="r"))
+        live: List[str] = []
+
+        def real(name, params):
+            live.append(name)
+            return "live"
+
+        rep = ReplayToolExecutor(cas, real=real, strict=False)
+        assert rep("unrecorded", {}) == "live"
+        assert live == ["unrecorded"]
+
+    def test_lenient_returns_none_with_no_real(self):
+        cas = self._cassette(Interaction(tool="search", returns="r"))
+        rep = ReplayToolExecutor(cas, real=None, strict=False)
+        assert rep("unrecorded", {}) is None
+
+    def test_remaining_reports_unused(self):
+        cas = self._cassette(
+            Interaction(tool="search", returns="r1"),
+            Interaction(tool="search", returns="r2"),
+        )
+        rep = ReplayToolExecutor(cas)
+        rep("search", {})
+        assert rep.remaining() == {"search": 1}
+
+
+# ============================================================================
+# On-disk format — versioning + round-trip
+# ============================================================================
+
+
+class TestCassettePersistence:
+    def test_save_and_load_round_trip(self, tmp_path: Path):
+        cas = new_cassette("my-test", adapter="anthropic")
+        cas.interactions.append(Interaction(tool="search", params={"q": "x"}, returns=[1, 2, 3]))
+        path = tmp_path / "c.json"
+        save_cassette(cas, path)
+        loaded = load_cassette(path)
+        assert loaded.test_name == "my-test"
+        assert loaded.adapter == "anthropic"
+        assert loaded.version == CASSETTE_FORMAT_VERSION
+        assert loaded.interactions[0].tool == "search"
+        assert loaded.interactions[0].returns == [1, 2, 3]
+
+    def test_load_rejects_future_version(self, tmp_path: Path):
+        path = tmp_path / "c.json"
+        path.write_text('{"version": 99, "test_name": "t", "recorded_at": "x", "interactions": []}')
+        with pytest.raises(CassetteError, match="format v99"):
+            load_cassette(path)
+
+    def test_cassette_path_replaces_slashes(self):
+        p = cassette_path_for("billing/refund")
+        assert p.name == "billing__refund.json"
+
+
+# ============================================================================
+# End-to-end: record once, replay deterministically
+# ============================================================================
+
+
+class TestRoundTripWithSimulator:
+    @pytest.mark.asyncio
+    async def test_record_then_replay_yields_same_outputs(self, tmp_path: Path):
+        # The "real" tool is a counter that returns a different value each
+        # call. If replay actually serves from the cassette (and not from
+        # the live counter), the second pass must produce identical output.
+        counter = {"n": 0}
+
+        def real(name, params):
+            counter["n"] += 1
+            return f"call-{counter['n']}-{name}"
+
+        plan = [
+            {"tool": "alpha", "params": {}},
+            {"tool": "beta", "params": {}},
+            {"tool": "alpha", "params": {}},
+        ]
+
+        # ── Record pass ──
+        record_adapter = _ScriptedAdapter(plan)
+        record_adapter.tool_executor = real
+        sim = Simulator(record_adapter, MockSpec())
+        rec_trace, rec_result = await sim.run(_case("rt"), record=True)
+
+        assert rec_result.recorded_cassette is not None
+        cassette = rec_result.recorded_cassette
+        assert len(cassette.interactions) == 3
+        assert cassette.adapter == "scripted"
+
+        path = tmp_path / "rt.json"
+        save_cassette(cassette, path)
+
+        # ── Replay pass ── against an executor that would explode if used.
+        def must_not_call(name, params):
+            raise AssertionError(f"replay leaked to live executor: {name}")
+
+        replay_adapter = _ScriptedAdapter(plan)
+        replay_adapter.tool_executor = must_not_call
+        sim2 = Simulator(replay_adapter, MockSpec(strict=True))
+        loaded = load_cassette(path)
+        rep_trace, _ = await sim2.run(_case("rt"), replay_cassette=loaded)
+
+        # Replay outputs match what was recorded — not what `real` would
+        # return now (counter has advanced).
+        assert rep_trace.final_output == rec_trace.final_output
+
+    @pytest.mark.asyncio
+    async def test_recording_skipped_for_mocked_calls(self):
+        """Synthetic mock results must not pollute the cassette."""
+        live_calls: List[str] = []
+
+        def real(name, params):
+            live_calls.append(name)
+            return f"live-{name}"
+
+        plan = [
+            {"tool": "mocked_tool", "params": {}},
+            {"tool": "live_tool", "params": {}},
+        ]
+        adapter = _ScriptedAdapter(plan)
+        adapter.tool_executor = real
+
+        spec = MockSpec(tool_mocks=[ToolMock(tool="mocked_tool", returns="from-mock")])
+        _, result = await Simulator(adapter, spec).run(_case("mix"), record=True)
+
+        cas = result.recorded_cassette
+        assert cas is not None
+        # Only the unmocked tool reached the recorder.
+        assert [i.tool for i in cas.interactions] == ["live_tool"]
+        assert live_calls == ["live_tool"]
+
+
+# ============================================================================
+# CLI integration
+# ============================================================================
+
+
+class TestSimulateCassetteCLI:
+    def test_record_and_replay_flags_mutually_exclusive(self, tmp_path: Path):
+        from evalview.commands.simulate_cmd import simulate
+
+        (tmp_path / "t.yaml").write_text(yaml.safe_dump({
+            "name": "t",
+            "input": {"query": "x"},
+            "expected": {},
+            "thresholds": {"min_score": 0},
+        }))
+        runner = CliRunner()
+        result = runner.invoke(simulate, [str(tmp_path), "--record", "--replay"])
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output.lower()
+
+    def test_replay_without_cassette_errors(self, tmp_path: Path):
+        from evalview.commands.simulate_cmd import simulate
+
+        (tmp_path / "t.yaml").write_text(yaml.safe_dump({
+            "name": "no-cassette",
+            "adapter": "http",
+            "endpoint": "http://127.0.0.1:9999",
+            "input": {"query": "x"},
+            "expected": {},
+            "thresholds": {"min_score": 0},
+        }))
+        runner = CliRunner()
+        result = runner.invoke(
+            simulate,
+            [str(tmp_path), "--replay", "--cassette-dir", str(tmp_path / "c")],
+        )
+        assert result.exit_code != 0
+        assert "no cassette found" in result.output.lower()

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -249,6 +249,102 @@ class TestSimulatorVariants:
 
 
 # ============================================================================
+# Adapter capability check — uninterceptable adapters fail loudly
+# ============================================================================
+
+
+class _UninterceptableAdapter(AgentAdapter):
+    """Adapter with no `tool_executor` and no `install_mock_interceptor`.
+
+    Models the LangGraph-Cloud / generic-HTTP case where the agent
+    runs server-side and there's no in-process seam for the simulator
+    to swap. Returns a trivial trace if it ever gets called.
+    """
+
+    @property
+    def name(self) -> str:
+        return "uninterceptable"
+
+    async def execute(self, query, context=None):
+        return ExecutionTrace(
+            session_id="u",
+            start_time=datetime(2026, 4, 20, 10, 0, 0),
+            end_time=datetime(2026, 4, 20, 10, 0, 1),
+            steps=[],
+            final_output="",
+            metrics=ExecutionMetrics(total_cost=0.0, total_latency=0.0),
+        )
+
+
+class TestAdapterCapability:
+    def test_capability_reports_truthfully(self):
+        from evalview.core.simulation import adapter_simulation_capability
+
+        cap_full = adapter_simulation_capability(_FakeAdapter(plan=[]))
+        # _FakeAdapter exposes both seams.
+        assert cap_full == {"tools": True, "responses": True, "http": False}
+
+        cap_none = adapter_simulation_capability(_UninterceptableAdapter())
+        assert cap_none == {"tools": False, "responses": False, "http": False}
+
+    @pytest.mark.asyncio
+    async def test_strict_raises_on_uninterceptable(self):
+        from evalview.core.simulation import UninterceptableAdapterError
+
+        sim = Simulator(_UninterceptableAdapter(), MockSpec(strict=True))
+        with pytest.raises(UninterceptableAdapterError, match="no tool interception seam"):
+            await sim.run(_case())
+
+    @pytest.mark.asyncio
+    async def test_record_raises_on_uninterceptable(self):
+        from evalview.core.simulation import UninterceptableAdapterError
+
+        sim = Simulator(_UninterceptableAdapter(), MockSpec())
+        with pytest.raises(UninterceptableAdapterError):
+            await sim.run(_case(), record=True)
+
+    @pytest.mark.asyncio
+    async def test_replay_raises_on_uninterceptable(self):
+        from evalview.core.simulation import UninterceptableAdapterError
+        from evalview.core.types import Cassette as _Cassette
+
+        cassette = _Cassette(test_name="t", recorded_at="x", interactions=[])
+        sim = Simulator(_UninterceptableAdapter(), MockSpec())
+        with pytest.raises(UninterceptableAdapterError):
+            await sim.run(_case(), replay_cassette=cassette)
+
+    @pytest.mark.asyncio
+    async def test_lenient_warns_but_proceeds(self, caplog):
+        # No record / replay / strict — uninterceptable run is allowed
+        # but must surface a WARNING so the user knows the run is live.
+        import logging
+        sim = Simulator(_UninterceptableAdapter(), MockSpec())
+        with caplog.at_level(logging.WARNING, logger="evalview.core.simulation"):
+            _, result = await sim.run(_case())
+        assert any("no tool interception seam" in r.message for r in caplog.records)
+        assert result.adapter_capability == {"tools": False, "responses": False, "http": False}
+
+    @pytest.mark.asyncio
+    async def test_allow_live_downgrades_warning_to_info(self, caplog):
+        import logging
+        sim = Simulator(_UninterceptableAdapter(), MockSpec())
+        with caplog.at_level(logging.DEBUG, logger="evalview.core.simulation"):
+            await sim.run(_case(), allow_live=True)
+        # Same message, but at INFO level (no WARNING).
+        warns = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        infos = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert not warns
+        assert any("no tool interception seam" in r.message for r in infos)
+
+    @pytest.mark.asyncio
+    async def test_capability_recorded_on_interceptable_adapter(self):
+        sim = Simulator(_FakeAdapter(plan=[]), MockSpec())
+        _, result = await sim.run(_case())
+        assert result.adapter_capability["tools"] is True
+        assert result.adapter_capability["responses"] is True
+
+
+# ============================================================================
 # Response / HTTP mock matching (public helpers)
 # ============================================================================
 

--- a/uv.lock
+++ b/uv.lock
@@ -58,6 +58,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "backoff"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -514,6 +523,18 @@ toml = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -542,13 +563,16 @@ wheels = [
 
 [[package]]
 name = "evalview"
-version = "0.5.3"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "httpx" },
+    { name = "jinja2" },
+    { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "openai" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
@@ -556,12 +580,13 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.optional-dependencies]
 all = [
     { name = "cohere" },
-    { name = "jinja2" },
+    { name = "croniter" },
     { name = "mistralai", version = "1.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "mistralai", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "plotly" },
@@ -595,8 +620,10 @@ mistral = [
     { name = "mistralai", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 reports = [
-    { name = "jinja2" },
     { name = "plotly" },
+]
+schedule = [
+    { name = "croniter" },
 ]
 telemetry = [
     { name = "posthog", version = "6.9.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -614,11 +641,13 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
     { name = "cohere", marker = "extra == 'all'", specifier = ">=5.0.0" },
     { name = "cohere", marker = "extra == 'cohere'", specifier = ">=5.0.0" },
+    { name = "croniter", marker = "extra == 'all'", specifier = ">=2.0" },
+    { name = "croniter", marker = "extra == 'schedule'", specifier = ">=2.0" },
     { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.109.0" },
     { name = "httpx", specifier = ">=0.26.0" },
-    { name = "jinja2", marker = "extra == 'all'", specifier = ">=3.0" },
+    { name = "jinja2", specifier = ">=3.0" },
     { name = "jinja2", marker = "extra == 'dev'", specifier = ">=3.0" },
-    { name = "jinja2", marker = "extra == 'reports'", specifier = ">=3.0" },
+    { name = "jsonschema", specifier = ">=4.0.0" },
     { name = "mistralai", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },
@@ -638,13 +667,14 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "uvicorn", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "watchdog", marker = "extra == 'all'", specifier = ">=3.0" },
     { name = "watchdog", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "watchdog", marker = "extra == 'watch'", specifier = ">=3.0" },
 ]
-provides-extras = ["reports", "watch", "telemetry", "cohere", "mistral", "all", "dev"]
+provides-extras = ["reports", "watch", "schedule", "telemetry", "cohere", "mistral", "all", "dev"]
 
 [[package]]
 name = "exceptiongroup"
@@ -1052,6 +1082,55 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/15/d6eb3b770f6a0d332675141ab3962fd4a7c270ede3515d9f3583e1d28276/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:89163163c0934854a668ed783a2546a0617f71706a2551a4a0666d91ab365d6b", size = 304233, upload-time = "2025-11-09T20:49:18.734Z" },
     { url = "https://files.pythonhosted.org/packages/8c/3e/e7e06743294eea2cf02ced6aa0ff2ad237367394e37a0e2b4a1108c67a36/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d96b264ab7d34bbb2312dedc47ce07cd53f06835eacbc16dde3761f47c3a9e7f", size = 338537, upload-time = "2025-11-09T20:49:20.317Z" },
     { url = "https://files.pythonhosted.org/packages/2f/9c/6753e6522b8d0ef07d3a3d239426669e984fb0eba15a315cdbc1253904e4/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c24e864cb30ab82311c6425655b0cdab0a98c5d973b065c66a3f020740c2324c", size = 346110, upload-time = "2025-11-09T20:49:21.817Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.25.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "attrs", marker = "python_full_version < '3.10'" },
+    { name = "jsonschema-specifications", marker = "python_full_version < '3.10'" },
+    { name = "referencing", version = "0.36.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "rpds-py", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63", size = 90040, upload-time = "2025-08-18T17:03:48.373Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "attrs", marker = "python_full_version >= '3.10'" },
+    { name = "jsonschema-specifications", marker = "python_full_version >= '3.10'" },
+    { name = "referencing", version = "0.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing", version = "0.36.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "referencing", version = "0.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -2002,6 +2081,40 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.36.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "attrs", marker = "python_full_version < '3.10'" },
+    { name = "rpds-py", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775, upload-time = "2025-01-25T08:48:14.241Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "attrs", marker = "python_full_version >= '3.10'" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2028,6 +2141,296 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.27.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/dd/2c0cbe774744272b0ae725f44032c77bdcab6e8bcf544bffa3b6e70c8dba/rpds_py-0.27.1.tar.gz", hash = "sha256:26a1c73171d10b7acccbded82bf6a586ab8203601e565badc74bbbf8bc5a10f8", size = 27479, upload-time = "2025-08-27T12:16:36.024Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/ed/3aef893e2dd30e77e35d20d4ddb45ca459db59cead748cad9796ad479411/rpds_py-0.27.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:68afeec26d42ab3b47e541b272166a0b4400313946871cba3ed3a4fc0cab1cef", size = 371606, upload-time = "2025-08-27T12:12:25.189Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/82/9818b443e5d3eb4c83c3994561387f116aae9833b35c484474769c4a8faf/rpds_py-0.27.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:74e5b2f7bb6fa38b1b10546d27acbacf2a022a8b5543efb06cfebc72a59c85be", size = 353452, upload-time = "2025-08-27T12:12:27.433Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c7/d2a110ffaaa397fc6793a83c7bd3545d9ab22658b7cdff05a24a4535cc45/rpds_py-0.27.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9024de74731df54546fab0bfbcdb49fae19159ecaecfc8f37c18d2c7e2c0bd61", size = 381519, upload-time = "2025-08-27T12:12:28.719Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/bc/e89581d1f9d1be7d0247eaef602566869fdc0d084008ba139e27e775366c/rpds_py-0.27.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:31d3ebadefcd73b73928ed0b2fd696f7fefda8629229f81929ac9c1854d0cffb", size = 394424, upload-time = "2025-08-27T12:12:30.207Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/2e/36a6861f797530e74bb6ed53495f8741f1ef95939eed01d761e73d559067/rpds_py-0.27.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b2e7f8f169d775dd9092a1743768d771f1d1300453ddfe6325ae3ab5332b4657", size = 523467, upload-time = "2025-08-27T12:12:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/c1bc2be32564fa499f988f0a5c6505c2f4746ef96e58e4d7de5cf923d77e/rpds_py-0.27.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d905d16f77eb6ab2e324e09bfa277b4c8e5e6b8a78a3e7ff8f3cdf773b4c013", size = 402660, upload-time = "2025-08-27T12:12:33.444Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ec/ef8bf895f0628dd0a59e54d81caed6891663cb9c54a0f4bb7da918cb88cf/rpds_py-0.27.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50c946f048209e6362e22576baea09193809f87687a95a8db24e5fbdb307b93a", size = 384062, upload-time = "2025-08-27T12:12:34.857Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f7/f47ff154be8d9a5e691c083a920bba89cef88d5247c241c10b9898f595a1/rpds_py-0.27.1-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:3deab27804d65cd8289eb814c2c0e807c4b9d9916c9225e363cb0cf875eb67c1", size = 401289, upload-time = "2025-08-27T12:12:36.085Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d9/ca410363efd0615814ae579f6829cafb39225cd63e5ea5ed1404cb345293/rpds_py-0.27.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8b61097f7488de4be8244c89915da8ed212832ccf1e7c7753a25a394bf9b1f10", size = 417718, upload-time = "2025-08-27T12:12:37.401Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a0/8cb5c2ff38340f221cc067cc093d1270e10658ba4e8d263df923daa18e86/rpds_py-0.27.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8a3f29aba6e2d7d90528d3c792555a93497fe6538aa65eb675b44505be747808", size = 558333, upload-time = "2025-08-27T12:12:38.672Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/8c/1b0de79177c5d5103843774ce12b84caa7164dfc6cd66378768d37db11bf/rpds_py-0.27.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:dd6cd0485b7d347304067153a6dc1d73f7d4fd995a396ef32a24d24b8ac63ac8", size = 589127, upload-time = "2025-08-27T12:12:41.48Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/5e/26abb098d5e01266b0f3a2488d299d19ccc26849735d9d2b95c39397e945/rpds_py-0.27.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6f4461bf931108c9fa226ffb0e257c1b18dc2d44cd72b125bec50ee0ab1248a9", size = 554899, upload-time = "2025-08-27T12:12:42.925Z" },
+    { url = "https://files.pythonhosted.org/packages/de/41/905cc90ced13550db017f8f20c6d8e8470066c5738ba480d7ba63e3d136b/rpds_py-0.27.1-cp310-cp310-win32.whl", hash = "sha256:ee5422d7fb21f6a00c1901bf6559c49fee13a5159d0288320737bbf6585bd3e4", size = 217450, upload-time = "2025-08-27T12:12:44.813Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3d/6bef47b0e253616ccdf67c283e25f2d16e18ccddd38f92af81d5a3420206/rpds_py-0.27.1-cp310-cp310-win_amd64.whl", hash = "sha256:3e039aabf6d5f83c745d5f9a0a381d031e9ed871967c0a5c38d201aca41f3ba1", size = 228447, upload-time = "2025-08-27T12:12:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c1/7907329fbef97cbd49db6f7303893bd1dd5a4a3eae415839ffdfb0762cae/rpds_py-0.27.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:be898f271f851f68b318872ce6ebebbc62f303b654e43bf72683dbdc25b7c881", size = 371063, upload-time = "2025-08-27T12:12:47.856Z" },
+    { url = "https://files.pythonhosted.org/packages/11/94/2aab4bc86228bcf7c48760990273653a4900de89c7537ffe1b0d6097ed39/rpds_py-0.27.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:62ac3d4e3e07b58ee0ddecd71d6ce3b1637de2d373501412df395a0ec5f9beb5", size = 353210, upload-time = "2025-08-27T12:12:49.187Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/57/f5eb3ecf434342f4f1a46009530e93fd201a0b5b83379034ebdb1d7c1a58/rpds_py-0.27.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4708c5c0ceb2d034f9991623631d3d23cb16e65c83736ea020cdbe28d57c0a0e", size = 381636, upload-time = "2025-08-27T12:12:50.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f4/ef95c5945e2ceb5119571b184dd5a1cc4b8541bbdf67461998cfeac9cb1e/rpds_py-0.27.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:abfa1171a9952d2e0002aba2ad3780820b00cc3d9c98c6630f2e93271501f66c", size = 394341, upload-time = "2025-08-27T12:12:52.024Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/7e/4bd610754bf492d398b61725eb9598ddd5eb86b07d7d9483dbcd810e20bc/rpds_py-0.27.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4b507d19f817ebaca79574b16eb2ae412e5c0835542c93fe9983f1e432aca195", size = 523428, upload-time = "2025-08-27T12:12:53.779Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e5/059b9f65a8c9149361a8b75094864ab83b94718344db511fd6117936ed2a/rpds_py-0.27.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:168b025f8fd8d8d10957405f3fdcef3dc20f5982d398f90851f4abc58c566c52", size = 402923, upload-time = "2025-08-27T12:12:55.15Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/48/64cabb7daced2968dd08e8a1b7988bf358d7bd5bcd5dc89a652f4668543c/rpds_py-0.27.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb56c6210ef77caa58e16e8c17d35c63fe3f5b60fd9ba9d424470c3400bcf9ed", size = 384094, upload-time = "2025-08-27T12:12:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e1/dc9094d6ff566bff87add8a510c89b9e158ad2ecd97ee26e677da29a9e1b/rpds_py-0.27.1-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:d252f2d8ca0195faa707f8eb9368955760880b2b42a8ee16d382bf5dd807f89a", size = 401093, upload-time = "2025-08-27T12:12:58.985Z" },
+    { url = "https://files.pythonhosted.org/packages/37/8e/ac8577e3ecdd5593e283d46907d7011618994e1d7ab992711ae0f78b9937/rpds_py-0.27.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6e5e54da1e74b91dbc7996b56640f79b195d5925c2b78efaa8c5d53e1d88edde", size = 417969, upload-time = "2025-08-27T12:13:00.367Z" },
+    { url = "https://files.pythonhosted.org/packages/66/6d/87507430a8f74a93556fe55c6485ba9c259949a853ce407b1e23fea5ba31/rpds_py-0.27.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ffce0481cc6e95e5b3f0a47ee17ffbd234399e6d532f394c8dce320c3b089c21", size = 558302, upload-time = "2025-08-27T12:13:01.737Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/bb/1db4781ce1dda3eecc735e3152659a27b90a02ca62bfeea17aee45cc0fbc/rpds_py-0.27.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a205fdfe55c90c2cd8e540ca9ceba65cbe6629b443bc05db1f590a3db8189ff9", size = 589259, upload-time = "2025-08-27T12:13:03.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/0e/ae1c8943d11a814d01b482e1f8da903f88047a962dff9bbdadf3bd6e6fd1/rpds_py-0.27.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:689fb5200a749db0415b092972e8eba85847c23885c8543a8b0f5c009b1a5948", size = 554983, upload-time = "2025-08-27T12:13:04.516Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d5/0b2a55415931db4f112bdab072443ff76131b5ac4f4dc98d10d2d357eb03/rpds_py-0.27.1-cp311-cp311-win32.whl", hash = "sha256:3182af66048c00a075010bc7f4860f33913528a4b6fc09094a6e7598e462fe39", size = 217154, upload-time = "2025-08-27T12:13:06.278Z" },
+    { url = "https://files.pythonhosted.org/packages/24/75/3b7ffe0d50dc86a6a964af0d1cc3a4a2cdf437cb7b099a4747bbb96d1819/rpds_py-0.27.1-cp311-cp311-win_amd64.whl", hash = "sha256:b4938466c6b257b2f5c4ff98acd8128ec36b5059e5c8f8372d79316b1c36bb15", size = 228627, upload-time = "2025-08-27T12:13:07.625Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3f/4fd04c32abc02c710f09a72a30c9a55ea3cc154ef8099078fd50a0596f8e/rpds_py-0.27.1-cp311-cp311-win_arm64.whl", hash = "sha256:2f57af9b4d0793e53266ee4325535a31ba48e2f875da81a9177c9926dfa60746", size = 220998, upload-time = "2025-08-27T12:13:08.972Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/fe/38de28dee5df58b8198c743fe2bea0c785c6d40941b9950bac4cdb71a014/rpds_py-0.27.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ae2775c1973e3c30316892737b91f9283f9908e3cc7625b9331271eaaed7dc90", size = 361887, upload-time = "2025-08-27T12:13:10.233Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/4b6c7eedc7dd90986bf0fab6ea2a091ec11c01b15f8ba0a14d3f80450468/rpds_py-0.27.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2643400120f55c8a96f7c9d858f7be0c88d383cd4653ae2cf0d0c88f668073e5", size = 345795, upload-time = "2025-08-27T12:13:11.65Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/0e/e650e1b81922847a09cca820237b0edee69416a01268b7754d506ade11ad/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16323f674c089b0360674a4abd28d5042947d54ba620f72514d69be4ff64845e", size = 385121, upload-time = "2025-08-27T12:13:13.008Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ea/b306067a712988e2bff00dcc7c8f31d26c29b6d5931b461aa4b60a013e33/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a1f4814b65eacac94a00fc9a526e3fdafd78e439469644032032d0d63de4881", size = 398976, upload-time = "2025-08-27T12:13:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0a/26dc43c8840cb8fe239fe12dbc8d8de40f2365e838f3d395835dde72f0e5/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ba32c16b064267b22f1850a34051121d423b6f7338a12b9459550eb2096e7ec", size = 525953, upload-time = "2025-08-27T12:13:15.774Z" },
+    { url = "https://files.pythonhosted.org/packages/22/14/c85e8127b573aaf3a0cbd7fbb8c9c99e735a4a02180c84da2a463b766e9e/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5c20f33fd10485b80f65e800bbe5f6785af510b9f4056c5a3c612ebc83ba6cb", size = 407915, upload-time = "2025-08-27T12:13:17.379Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/7b/8f4fee9ba1fb5ec856eb22d725a4efa3deb47f769597c809e03578b0f9d9/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:466bfe65bd932da36ff279ddd92de56b042f2266d752719beb97b08526268ec5", size = 386883, upload-time = "2025-08-27T12:13:18.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/47/28fa6d60f8b74fcdceba81b272f8d9836ac0340570f68f5df6b41838547b/rpds_py-0.27.1-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:41e532bbdcb57c92ba3be62c42e9f096431b4cf478da9bc3bc6ce5c38ab7ba7a", size = 405699, upload-time = "2025-08-27T12:13:20.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/fd/c5987b5e054548df56953a21fe2ebed51fc1ec7c8f24fd41c067b68c4a0a/rpds_py-0.27.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f149826d742b406579466283769a8ea448eed82a789af0ed17b0cd5770433444", size = 423713, upload-time = "2025-08-27T12:13:21.436Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ba/3c4978b54a73ed19a7d74531be37a8bcc542d917c770e14d372b8daea186/rpds_py-0.27.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80c60cfb5310677bd67cb1e85a1e8eb52e12529545441b43e6f14d90b878775a", size = 562324, upload-time = "2025-08-27T12:13:22.789Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/6c/6943a91768fec16db09a42b08644b960cff540c66aab89b74be6d4a144ba/rpds_py-0.27.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:7ee6521b9baf06085f62ba9c7a3e5becffbc32480d2f1b351559c001c38ce4c1", size = 593646, upload-time = "2025-08-27T12:13:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/11/73/9d7a8f4be5f4396f011a6bb7a19fe26303a0dac9064462f5651ced2f572f/rpds_py-0.27.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a512c8263249a9d68cac08b05dd59d2b3f2061d99b322813cbcc14c3c7421998", size = 558137, upload-time = "2025-08-27T12:13:25.557Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/96/6772cbfa0e2485bcceef8071de7821f81aeac8bb45fbfd5542a3e8108165/rpds_py-0.27.1-cp312-cp312-win32.whl", hash = "sha256:819064fa048ba01b6dadc5116f3ac48610435ac9a0058bbde98e569f9e785c39", size = 221343, upload-time = "2025-08-27T12:13:26.967Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b6/c82f0faa9af1c6a64669f73a17ee0eeef25aff30bb9a1c318509efe45d84/rpds_py-0.27.1-cp312-cp312-win_amd64.whl", hash = "sha256:d9199717881f13c32c4046a15f024971a3b78ad4ea029e8da6b86e5aa9cf4594", size = 232497, upload-time = "2025-08-27T12:13:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/96/2817b44bd2ed11aebacc9251da03689d56109b9aba5e311297b6902136e2/rpds_py-0.27.1-cp312-cp312-win_arm64.whl", hash = "sha256:33aa65b97826a0e885ef6e278fbd934e98cdcfed80b63946025f01e2f5b29502", size = 222790, upload-time = "2025-08-27T12:13:29.71Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/77/610aeee8d41e39080c7e14afa5387138e3c9fa9756ab893d09d99e7d8e98/rpds_py-0.27.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:e4b9fcfbc021633863a37e92571d6f91851fa656f0180246e84cbd8b3f6b329b", size = 361741, upload-time = "2025-08-27T12:13:31.039Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/fc/c43765f201c6a1c60be2043cbdb664013def52460a4c7adace89d6682bf4/rpds_py-0.27.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1441811a96eadca93c517d08df75de45e5ffe68aa3089924f963c782c4b898cf", size = 345574, upload-time = "2025-08-27T12:13:32.902Z" },
+    { url = "https://files.pythonhosted.org/packages/20/42/ee2b2ca114294cd9847d0ef9c26d2b0851b2e7e00bf14cc4c0b581df0fc3/rpds_py-0.27.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55266dafa22e672f5a4f65019015f90336ed31c6383bd53f5e7826d21a0e0b83", size = 385051, upload-time = "2025-08-27T12:13:34.228Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e8/1e430fe311e4799e02e2d1af7c765f024e95e17d651612425b226705f910/rpds_py-0.27.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d78827d7ac08627ea2c8e02c9e5b41180ea5ea1f747e9db0915e3adf36b62dcf", size = 398395, upload-time = "2025-08-27T12:13:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/82/95/9dc227d441ff2670651c27a739acb2535ccaf8b351a88d78c088965e5996/rpds_py-0.27.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ae92443798a40a92dc5f0b01d8a7c93adde0c4dc965310a29ae7c64d72b9fad2", size = 524334, upload-time = "2025-08-27T12:13:37.562Z" },
+    { url = "https://files.pythonhosted.org/packages/87/01/a670c232f401d9ad461d9a332aa4080cd3cb1d1df18213dbd0d2a6a7ab51/rpds_py-0.27.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c46c9dd2403b66a2a3b9720ec4b74d4ab49d4fabf9f03dfdce2d42af913fe8d0", size = 407691, upload-time = "2025-08-27T12:13:38.94Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/0a14aebbaa26fe7fab4780c76f2239e76cc95a0090bdb25e31d95c492fcd/rpds_py-0.27.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2efe4eb1d01b7f5f1939f4ef30ecea6c6b3521eec451fb93191bf84b2a522418", size = 386868, upload-time = "2025-08-27T12:13:40.192Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/03/8c897fb8b5347ff6c1cc31239b9611c5bf79d78c984430887a353e1409a1/rpds_py-0.27.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:15d3b4d83582d10c601f481eca29c3f138d44c92187d197aff663a269197c02d", size = 405469, upload-time = "2025-08-27T12:13:41.496Z" },
+    { url = "https://files.pythonhosted.org/packages/da/07/88c60edc2df74850d496d78a1fdcdc7b54360a7f610a4d50008309d41b94/rpds_py-0.27.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4ed2e16abbc982a169d30d1a420274a709949e2cbdef119fe2ec9d870b42f274", size = 422125, upload-time = "2025-08-27T12:13:42.802Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/86/5f4c707603e41b05f191a749984f390dabcbc467cf833769b47bf14ba04f/rpds_py-0.27.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a75f305c9b013289121ec0f1181931975df78738cdf650093e6b86d74aa7d8dd", size = 562341, upload-time = "2025-08-27T12:13:44.472Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/92/3c0cb2492094e3cd9baf9e49bbb7befeceb584ea0c1a8b5939dca4da12e5/rpds_py-0.27.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:67ce7620704745881a3d4b0ada80ab4d99df390838839921f99e63c474f82cf2", size = 592511, upload-time = "2025-08-27T12:13:45.898Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/82e64fbb0047c46a168faa28d0d45a7851cd0582f850b966811d30f67ad8/rpds_py-0.27.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d992ac10eb86d9b6f369647b6a3f412fc0075cfd5d799530e84d335e440a002", size = 557736, upload-time = "2025-08-27T12:13:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/00/95/3c863973d409210da7fb41958172c6b7dbe7fc34e04d3cc1f10bb85e979f/rpds_py-0.27.1-cp313-cp313-win32.whl", hash = "sha256:4f75e4bd8ab8db624e02c8e2fc4063021b58becdbe6df793a8111d9343aec1e3", size = 221462, upload-time = "2025-08-27T12:13:48.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2c/5867b14a81dc217b56d95a9f2a40fdbc56a1ab0181b80132beeecbd4b2d6/rpds_py-0.27.1-cp313-cp313-win_amd64.whl", hash = "sha256:f9025faafc62ed0b75a53e541895ca272815bec18abe2249ff6501c8f2e12b83", size = 232034, upload-time = "2025-08-27T12:13:50.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/78/3958f3f018c01923823f1e47f1cc338e398814b92d83cd278364446fac66/rpds_py-0.27.1-cp313-cp313-win_arm64.whl", hash = "sha256:ed10dc32829e7d222b7d3b93136d25a406ba9788f6a7ebf6809092da1f4d279d", size = 222392, upload-time = "2025-08-27T12:13:52.587Z" },
+    { url = "https://files.pythonhosted.org/packages/01/76/1cdf1f91aed5c3a7bf2eba1f1c4e4d6f57832d73003919a20118870ea659/rpds_py-0.27.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:92022bbbad0d4426e616815b16bc4127f83c9a74940e1ccf3cfe0b387aba0228", size = 358355, upload-time = "2025-08-27T12:13:54.012Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6f/bf142541229374287604caf3bb2a4ae17f0a580798fd72d3b009b532db4e/rpds_py-0.27.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:47162fdab9407ec3f160805ac3e154df042e577dd53341745fc7fb3f625e6d92", size = 342138, upload-time = "2025-08-27T12:13:55.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/77/355b1c041d6be40886c44ff5e798b4e2769e497b790f0f7fd1e78d17e9a8/rpds_py-0.27.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb89bec23fddc489e5d78b550a7b773557c9ab58b7946154a10a6f7a214a48b2", size = 380247, upload-time = "2025-08-27T12:13:57.683Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a4/d9cef5c3946ea271ce2243c51481971cd6e34f21925af2783dd17b26e815/rpds_py-0.27.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e48af21883ded2b3e9eb48cb7880ad8598b31ab752ff3be6457001d78f416723", size = 390699, upload-time = "2025-08-27T12:13:59.137Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/06/005106a7b8c6c1a7e91b73169e49870f4af5256119d34a361ae5240a0c1d/rpds_py-0.27.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6f5b7bd8e219ed50299e58551a410b64daafb5017d54bbe822e003856f06a802", size = 521852, upload-time = "2025-08-27T12:14:00.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/3e/50fb1dac0948e17a02eb05c24510a8fe12d5ce8561c6b7b7d1339ab7ab9c/rpds_py-0.27.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08f1e20bccf73b08d12d804d6e1c22ca5530e71659e6673bce31a6bb71c1e73f", size = 402582, upload-time = "2025-08-27T12:14:02.034Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b0/f4e224090dc5b0ec15f31a02d746ab24101dd430847c4d99123798661bfc/rpds_py-0.27.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0dc5dceeaefcc96dc192e3a80bbe1d6c410c469e97bdd47494a7d930987f18b2", size = 384126, upload-time = "2025-08-27T12:14:03.437Z" },
+    { url = "https://files.pythonhosted.org/packages/54/77/ac339d5f82b6afff1df8f0fe0d2145cc827992cb5f8eeb90fc9f31ef7a63/rpds_py-0.27.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:d76f9cc8665acdc0c9177043746775aa7babbf479b5520b78ae4002d889f5c21", size = 399486, upload-time = "2025-08-27T12:14:05.443Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/29/3e1c255eee6ac358c056a57d6d6869baa00a62fa32eea5ee0632039c50a3/rpds_py-0.27.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:134fae0e36022edad8290a6661edf40c023562964efea0cc0ec7f5d392d2aaef", size = 414832, upload-time = "2025-08-27T12:14:06.902Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/db/6d498b844342deb3fa1d030598db93937a9964fcf5cb4da4feb5f17be34b/rpds_py-0.27.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:eb11a4f1b2b63337cfd3b4d110af778a59aae51c81d195768e353d8b52f88081", size = 557249, upload-time = "2025-08-27T12:14:08.37Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f3/690dd38e2310b6f68858a331399b4d6dbb9132c3e8ef8b4333b96caf403d/rpds_py-0.27.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:13e608ac9f50a0ed4faec0e90ece76ae33b34c0e8656e3dceb9a7db994c692cd", size = 587356, upload-time = "2025-08-27T12:14:10.034Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e3/84507781cccd0145f35b1dc32c72675200c5ce8d5b30f813e49424ef68fc/rpds_py-0.27.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dd2135527aa40f061350c3f8f89da2644de26cd73e4de458e79606384f4f68e7", size = 555300, upload-time = "2025-08-27T12:14:11.783Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ee/375469849e6b429b3516206b4580a79e9ef3eb12920ddbd4492b56eaacbe/rpds_py-0.27.1-cp313-cp313t-win32.whl", hash = "sha256:3020724ade63fe320a972e2ffd93b5623227e684315adce194941167fee02688", size = 216714, upload-time = "2025-08-27T12:14:13.629Z" },
+    { url = "https://files.pythonhosted.org/packages/21/87/3fc94e47c9bd0742660e84706c311a860dcae4374cf4a03c477e23ce605a/rpds_py-0.27.1-cp313-cp313t-win_amd64.whl", hash = "sha256:8ee50c3e41739886606388ba3ab3ee2aae9f35fb23f833091833255a31740797", size = 228943, upload-time = "2025-08-27T12:14:14.937Z" },
+    { url = "https://files.pythonhosted.org/packages/70/36/b6e6066520a07cf029d385de869729a895917b411e777ab1cde878100a1d/rpds_py-0.27.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:acb9aafccaae278f449d9c713b64a9e68662e7799dbd5859e2c6b3c67b56d334", size = 362472, upload-time = "2025-08-27T12:14:16.333Z" },
+    { url = "https://files.pythonhosted.org/packages/af/07/b4646032e0dcec0df9c73a3bd52f63bc6c5f9cda992f06bd0e73fe3fbebd/rpds_py-0.27.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b7fb801aa7f845ddf601c49630deeeccde7ce10065561d92729bfe81bd21fb33", size = 345676, upload-time = "2025-08-27T12:14:17.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/16/2f1003ee5d0af4bcb13c0cf894957984c32a6751ed7206db2aee7379a55e/rpds_py-0.27.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe0dd05afb46597b9a2e11c351e5e4283c741237e7f617ffb3252780cca9336a", size = 385313, upload-time = "2025-08-27T12:14:19.829Z" },
+    { url = "https://files.pythonhosted.org/packages/05/cd/7eb6dd7b232e7f2654d03fa07f1414d7dfc980e82ba71e40a7c46fd95484/rpds_py-0.27.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b6dfb0e058adb12d8b1d1b25f686e94ffa65d9995a5157afe99743bf7369d62b", size = 399080, upload-time = "2025-08-27T12:14:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/20/51/5829afd5000ec1cb60f304711f02572d619040aa3ec033d8226817d1e571/rpds_py-0.27.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed090ccd235f6fa8bb5861684567f0a83e04f52dfc2e5c05f2e4b1309fcf85e7", size = 523868, upload-time = "2025-08-27T12:14:23.485Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/30eebca20d5db95720ab4d2faec1b5e4c1025c473f703738c371241476a2/rpds_py-0.27.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bf876e79763eecf3e7356f157540d6a093cef395b65514f17a356f62af6cc136", size = 408750, upload-time = "2025-08-27T12:14:24.924Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1a/cdb5083f043597c4d4276eae4e4c70c55ab5accec078da8611f24575a367/rpds_py-0.27.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:12ed005216a51b1d6e2b02a7bd31885fe317e45897de81d86dcce7d74618ffff", size = 387688, upload-time = "2025-08-27T12:14:27.537Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/92/cf786a15320e173f945d205ab31585cc43969743bb1a48b6888f7a2b0a2d/rpds_py-0.27.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:ee4308f409a40e50593c7e3bb8cbe0b4d4c66d1674a316324f0c2f5383b486f9", size = 407225, upload-time = "2025-08-27T12:14:28.981Z" },
+    { url = "https://files.pythonhosted.org/packages/33/5c/85ee16df5b65063ef26017bef33096557a4c83fbe56218ac7cd8c235f16d/rpds_py-0.27.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0b08d152555acf1f455154d498ca855618c1378ec810646fcd7c76416ac6dc60", size = 423361, upload-time = "2025-08-27T12:14:30.469Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8e/1c2741307fcabd1a334ecf008e92c4f47bb6f848712cf15c923becfe82bb/rpds_py-0.27.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:dce51c828941973a5684d458214d3a36fcd28da3e1875d659388f4f9f12cc33e", size = 562493, upload-time = "2025-08-27T12:14:31.987Z" },
+    { url = "https://files.pythonhosted.org/packages/04/03/5159321baae9b2222442a70c1f988cbbd66b9be0675dd3936461269be360/rpds_py-0.27.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:c1476d6f29eb81aa4151c9a31219b03f1f798dc43d8af1250a870735516a1212", size = 592623, upload-time = "2025-08-27T12:14:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/39/c09fd1ad28b85bc1d4554a8710233c9f4cefd03d7717a1b8fbfd171d1167/rpds_py-0.27.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3ce0cac322b0d69b63c9cdb895ee1b65805ec9ffad37639f291dd79467bee675", size = 558800, upload-time = "2025-08-27T12:14:35.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d6/99228e6bbcf4baa764b18258f519a9035131d91b538d4e0e294313462a98/rpds_py-0.27.1-cp314-cp314-win32.whl", hash = "sha256:dfbfac137d2a3d0725758cd141f878bf4329ba25e34979797c89474a89a8a3a3", size = 221943, upload-time = "2025-08-27T12:14:36.898Z" },
+    { url = "https://files.pythonhosted.org/packages/be/07/c802bc6b8e95be83b79bdf23d1aa61d68324cb1006e245d6c58e959e314d/rpds_py-0.27.1-cp314-cp314-win_amd64.whl", hash = "sha256:a6e57b0abfe7cc513450fcf529eb486b6e4d3f8aee83e92eb5f1ef848218d456", size = 233739, upload-time = "2025-08-27T12:14:38.386Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/89/3e1b1c16d4c2d547c5717377a8df99aee8099ff050f87c45cb4d5fa70891/rpds_py-0.27.1-cp314-cp314-win_arm64.whl", hash = "sha256:faf8d146f3d476abfee026c4ae3bdd9ca14236ae4e4c310cbd1cf75ba33d24a3", size = 223120, upload-time = "2025-08-27T12:14:39.82Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/dc7931dc2fa4a6e46b2a4fa744a9fe5c548efd70e0ba74f40b39fa4a8c10/rpds_py-0.27.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:ba81d2b56b6d4911ce735aad0a1d4495e808b8ee4dc58715998741a26874e7c2", size = 358944, upload-time = "2025-08-27T12:14:41.199Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/22/4af76ac4e9f336bfb1a5f240d18a33c6b2fcaadb7472ac7680576512b49a/rpds_py-0.27.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:84f7d509870098de0e864cad0102711c1e24e9b1a50ee713b65928adb22269e4", size = 342283, upload-time = "2025-08-27T12:14:42.699Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/15/2a7c619b3c2272ea9feb9ade67a45c40b3eeb500d503ad4c28c395dc51b4/rpds_py-0.27.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9e960fc78fecd1100539f14132425e1d5fe44ecb9239f8f27f079962021523e", size = 380320, upload-time = "2025-08-27T12:14:44.157Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7d/4c6d243ba4a3057e994bb5bedd01b5c963c12fe38dde707a52acdb3849e7/rpds_py-0.27.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62f85b665cedab1a503747617393573995dac4600ff51869d69ad2f39eb5e817", size = 391760, upload-time = "2025-08-27T12:14:45.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/71/b19401a909b83bcd67f90221330bc1ef11bc486fe4e04c24388d28a618ae/rpds_py-0.27.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fed467af29776f6556250c9ed85ea5a4dd121ab56a5f8b206e3e7a4c551e48ec", size = 522476, upload-time = "2025-08-27T12:14:47.364Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/44/1a3b9715c0455d2e2f0f6df5ee6d6f5afdc423d0773a8a682ed2b43c566c/rpds_py-0.27.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f2729615f9d430af0ae6b36cf042cb55c0936408d543fb691e1a9e36648fd35a", size = 403418, upload-time = "2025-08-27T12:14:49.991Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/4b/fb6c4f14984eb56673bc868a66536f53417ddb13ed44b391998100a06a96/rpds_py-0.27.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b207d881a9aef7ba753d69c123a35d96ca7cb808056998f6b9e8747321f03b8", size = 384771, upload-time = "2025-08-27T12:14:52.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/56/d5265d2d28b7420d7b4d4d85cad8ef891760f5135102e60d5c970b976e41/rpds_py-0.27.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:639fd5efec029f99b79ae47e5d7e00ad8a773da899b6309f6786ecaf22948c48", size = 400022, upload-time = "2025-08-27T12:14:53.859Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e9/9f5fc70164a569bdd6ed9046486c3568d6926e3a49bdefeeccfb18655875/rpds_py-0.27.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fecc80cb2a90e28af8a9b366edacf33d7a91cbfe4c2c4544ea1246e949cfebeb", size = 416787, upload-time = "2025-08-27T12:14:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/64/56dd03430ba491db943a81dcdef115a985aac5f44f565cd39a00c766d45c/rpds_py-0.27.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:42a89282d711711d0a62d6f57d81aa43a1368686c45bc1c46b7f079d55692734", size = 557538, upload-time = "2025-08-27T12:14:57.245Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/36/92cc885a3129993b1d963a2a42ecf64e6a8e129d2c7cc980dbeba84e55fb/rpds_py-0.27.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:cf9931f14223de59551ab9d38ed18d92f14f055a5f78c1d8ad6493f735021bbb", size = 588512, upload-time = "2025-08-27T12:14:58.728Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/10/6b283707780a81919f71625351182b4f98932ac89a09023cb61865136244/rpds_py-0.27.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f39f58a27cc6e59f432b568ed8429c7e1641324fbe38131de852cd77b2d534b0", size = 555813, upload-time = "2025-08-27T12:15:00.334Z" },
+    { url = "https://files.pythonhosted.org/packages/04/2e/30b5ea18c01379da6272a92825dd7e53dc9d15c88a19e97932d35d430ef7/rpds_py-0.27.1-cp314-cp314t-win32.whl", hash = "sha256:d5fa0ee122dc09e23607a28e6d7b150da16c662e66409bbe85230e4c85bb528a", size = 217385, upload-time = "2025-08-27T12:15:01.937Z" },
+    { url = "https://files.pythonhosted.org/packages/32/7d/97119da51cb1dd3f2f3c0805f155a3aa4a95fa44fe7d78ae15e69edf4f34/rpds_py-0.27.1-cp314-cp314t-win_amd64.whl", hash = "sha256:6567d2bb951e21232c2f660c24cf3470bb96de56cdcb3f071a83feeaff8a2772", size = 230097, upload-time = "2025-08-27T12:15:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/6c/252e83e1ce7583c81f26d1d884b2074d40a13977e1b6c9c50bbf9a7f1f5a/rpds_py-0.27.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:c918c65ec2e42c2a78d19f18c553d77319119bf43aa9e2edf7fb78d624355527", size = 372140, upload-time = "2025-08-27T12:15:05.441Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/71/949c195d927c5aeb0d0629d329a20de43a64c423a6aa53836290609ef7ec/rpds_py-0.27.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1fea2b1a922c47c51fd07d656324531adc787e415c8b116530a1d29c0516c62d", size = 354086, upload-time = "2025-08-27T12:15:07.404Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/02/e43e332ad8ce4f6c4342d151a471a7f2900ed1d76901da62eb3762663a71/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbf94c58e8e0cd6b6f38d8de67acae41b3a515c26169366ab58bdca4a6883bb8", size = 382117, upload-time = "2025-08-27T12:15:09.275Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/05/b0fdeb5b577197ad72812bbdfb72f9a08fa1e64539cc3940b1b781cd3596/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c2a8fed130ce946d5c585eddc7c8eeef0051f58ac80a8ee43bd17835c144c2cc", size = 394520, upload-time = "2025-08-27T12:15:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1f/4cfef98b2349a7585181e99294fa2a13f0af06902048a5d70f431a66d0b9/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:037a2361db72ee98d829bc2c5b7cc55598ae0a5e0ec1823a56ea99374cfd73c1", size = 522657, upload-time = "2025-08-27T12:15:12.613Z" },
+    { url = "https://files.pythonhosted.org/packages/44/55/ccf37ddc4c6dce7437b335088b5ca18da864b334890e2fe9aa6ddc3f79a9/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5281ed1cc1d49882f9997981c88df1a22e140ab41df19071222f7e5fc4e72125", size = 402967, upload-time = "2025-08-27T12:15:14.113Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e5/5903f92e41e293b07707d5bf00ef39a0eb2af7190aff4beaf581a6591510/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fd50659a069c15eef8aa3d64bbef0d69fd27bb4a50c9ab4f17f83a16cbf8905", size = 384372, upload-time = "2025-08-27T12:15:15.842Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e3/fbb409e18aeefc01e49f5922ac63d2d914328430e295c12183ce56ebf76b/rpds_py-0.27.1-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:c4b676c4ae3921649a15d28ed10025548e9b561ded473aa413af749503c6737e", size = 401264, upload-time = "2025-08-27T12:15:17.388Z" },
+    { url = "https://files.pythonhosted.org/packages/55/79/529ad07794e05cb0f38e2f965fc5bb20853d523976719400acecc447ec9d/rpds_py-0.27.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:079bc583a26db831a985c5257797b2b5d3affb0386e7ff886256762f82113b5e", size = 418691, upload-time = "2025-08-27T12:15:19.144Z" },
+    { url = "https://files.pythonhosted.org/packages/33/39/6554a7fd6d9906fda2521c6d52f5d723dca123529fb719a5b5e074c15e01/rpds_py-0.27.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4e44099bd522cba71a2c6b97f68e19f40e7d85399de899d66cdb67b32d7cb786", size = 558989, upload-time = "2025-08-27T12:15:21.087Z" },
+    { url = "https://files.pythonhosted.org/packages/19/b2/76fa15173b6f9f445e5ef15120871b945fb8dd9044b6b8c7abe87e938416/rpds_py-0.27.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:e202e6d4188e53c6661af813b46c37ca2c45e497fc558bacc1a7630ec2695aec", size = 589835, upload-time = "2025-08-27T12:15:22.696Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/9e/5560a4b39bab780405bed8a88ee85b30178061d189558a86003548dea045/rpds_py-0.27.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f41f814b8eaa48768d1bb551591f6ba45f87ac76899453e8ccd41dba1289b04b", size = 555227, upload-time = "2025-08-27T12:15:24.278Z" },
+    { url = "https://files.pythonhosted.org/packages/52/d7/cd9c36215111aa65724c132bf709c6f35175973e90b32115dedc4ced09cb/rpds_py-0.27.1-cp39-cp39-win32.whl", hash = "sha256:9e71f5a087ead99563c11fdaceee83ee982fd39cf67601f4fd66cb386336ee52", size = 217899, upload-time = "2025-08-27T12:15:25.926Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e0/d75ab7b4dd8ba777f6b365adbdfc7614bbfe7c5f05703031dfa4b61c3d6c/rpds_py-0.27.1-cp39-cp39-win_amd64.whl", hash = "sha256:71108900c9c3c8590697244b9519017a400d9ba26a36c48381b3f64743a44aab", size = 228725, upload-time = "2025-08-27T12:15:27.398Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/63/b7cc415c345625d5e62f694ea356c58fb964861409008118f1245f8c3347/rpds_py-0.27.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7ba22cb9693df986033b91ae1d7a979bc399237d45fccf875b76f62bb9e52ddf", size = 371360, upload-time = "2025-08-27T12:15:29.218Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/12e1b24b560cf378b8ffbdb9dc73abd529e1adcfcf82727dfd29c4a7b88d/rpds_py-0.27.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5b640501be9288c77738b5492b3fd3abc4ba95c50c2e41273c8a1459f08298d3", size = 353933, upload-time = "2025-08-27T12:15:30.837Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/85/1bb2210c1f7a1b99e91fea486b9f0f894aa5da3a5ec7097cbad7dec6d40f/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb08b65b93e0c6dd70aac7f7890a9c0938d5ec71d5cb32d45cf844fb8ae47636", size = 382962, upload-time = "2025-08-27T12:15:32.348Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c9/a839b9f219cf80ed65f27a7f5ddbb2809c1b85c966020ae2dff490e0b18e/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d7ff07d696a7a38152ebdb8212ca9e5baab56656749f3d6004b34ab726b550b8", size = 394412, upload-time = "2025-08-27T12:15:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/02/2d/b1d7f928b0b1f4fc2e0133e8051d199b01d7384875adc63b6ddadf3de7e5/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fb7c72262deae25366e3b6c0c0ba46007967aea15d1eea746e44ddba8ec58dcc", size = 523972, upload-time = "2025-08-27T12:15:35.377Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/af/2cbf56edd2d07716df1aec8a726b3159deb47cb5c27e1e42b71d705a7c2f/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b002cab05d6339716b03a4a3a2ce26737f6231d7b523f339fa061d53368c9d8", size = 403273, upload-time = "2025-08-27T12:15:37.051Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/93/425e32200158d44ff01da5d9612c3b6711fe69f606f06e3895511f17473b/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:23f6b69d1c26c4704fec01311963a41d7de3ee0570a84ebde4d544e5a1859ffc", size = 385278, upload-time = "2025-08-27T12:15:38.571Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1a/1a04a915ecd0551bfa9e77b7672d1937b4b72a0fc204a17deef76001cfb2/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:530064db9146b247351f2a0250b8f00b289accea4596a033e94be2389977de71", size = 402084, upload-time = "2025-08-27T12:15:40.529Z" },
+    { url = "https://files.pythonhosted.org/packages/51/f7/66585c0fe5714368b62951d2513b684e5215beaceab2c6629549ddb15036/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b90b0496570bd6b0321724a330d8b545827c4df2034b6ddfc5f5275f55da2ad", size = 419041, upload-time = "2025-08-27T12:15:42.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/7e/83a508f6b8e219bba2d4af077c35ba0e0cdd35a751a3be6a7cba5a55ad71/rpds_py-0.27.1-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:879b0e14a2da6a1102a3fc8af580fc1ead37e6d6692a781bd8c83da37429b5ab", size = 560084, upload-time = "2025-08-27T12:15:43.839Z" },
+    { url = "https://files.pythonhosted.org/packages/66/66/bb945683b958a1b19eb0fe715594630d0f36396ebdef4d9b89c2fa09aa56/rpds_py-0.27.1-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:0d807710df3b5faa66c731afa162ea29717ab3be17bdc15f90f2d9f183da4059", size = 590115, upload-time = "2025-08-27T12:15:46.647Z" },
+    { url = "https://files.pythonhosted.org/packages/12/00/ccfaafaf7db7e7adace915e5c2f2c2410e16402561801e9c7f96683002d3/rpds_py-0.27.1-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:3adc388fc3afb6540aec081fa59e6e0d3908722771aa1e37ffe22b220a436f0b", size = 556561, upload-time = "2025-08-27T12:15:48.219Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/b7/92b6ed9aad103bfe1c45df98453dfae40969eef2cb6c6239c58d7e96f1b3/rpds_py-0.27.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:c796c0c1cc68cb08b0284db4229f5af76168172670c74908fdbd4b7d7f515819", size = 229125, upload-time = "2025-08-27T12:15:49.956Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ed/e1fba02de17f4f76318b834425257c8ea297e415e12c68b4361f63e8ae92/rpds_py-0.27.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:cdfe4bb2f9fe7458b7453ad3c33e726d6d1c7c0a72960bcc23800d77384e42df", size = 371402, upload-time = "2025-08-27T12:15:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7c/e16b959b316048b55585a697e94add55a4ae0d984434d279ea83442e460d/rpds_py-0.27.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:8fabb8fd848a5f75a2324e4a84501ee3a5e3c78d8603f83475441866e60b94a3", size = 354084, upload-time = "2025-08-27T12:15:53.219Z" },
+    { url = "https://files.pythonhosted.org/packages/de/c1/ade645f55de76799fdd08682d51ae6724cb46f318573f18be49b1e040428/rpds_py-0.27.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eda8719d598f2f7f3e0f885cba8646644b55a187762bec091fa14a2b819746a9", size = 383090, upload-time = "2025-08-27T12:15:55.158Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/27/89070ca9b856e52960da1472efcb6c20ba27cfe902f4f23ed095b9cfc61d/rpds_py-0.27.1-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c64d07e95606ec402a0a1c511fe003873fa6af630bda59bac77fac8b4318ebc", size = 394519, upload-time = "2025-08-27T12:15:57.238Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/28/be120586874ef906aa5aeeae95ae8df4184bc757e5b6bd1c729ccff45ed5/rpds_py-0.27.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:93a2ed40de81bcff59aabebb626562d48332f3d028ca2036f1d23cbb52750be4", size = 523817, upload-time = "2025-08-27T12:15:59.237Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ef/70cc197bc11cfcde02a86f36ac1eed15c56667c2ebddbdb76a47e90306da/rpds_py-0.27.1-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:387ce8c44ae94e0ec50532d9cb0edce17311024c9794eb196b90e1058aadeb66", size = 403240, upload-time = "2025-08-27T12:16:00.923Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/46936cca449f7f518f2f4996e0e8344db4b57e2081e752441154089d2a5f/rpds_py-0.27.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aaf94f812c95b5e60ebaf8bfb1898a7d7cb9c1af5744d4a67fa47796e0465d4e", size = 385194, upload-time = "2025-08-27T12:16:02.802Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/62/29c0d3e5125c3270b51415af7cbff1ec587379c84f55a5761cc9efa8cd06/rpds_py-0.27.1-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:4848ca84d6ded9b58e474dfdbad4b8bfb450344c0551ddc8d958bf4b36aa837c", size = 402086, upload-time = "2025-08-27T12:16:04.806Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/66/03e1087679227785474466fdd04157fb793b3b76e3fcf01cbf4c693c1949/rpds_py-0.27.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2bde09cbcf2248b73c7c323be49b280180ff39fadcfe04e7b6f54a678d02a7cf", size = 419272, upload-time = "2025-08-27T12:16:06.471Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/24/e3e72d265121e00b063aef3e3501e5b2473cf1b23511d56e529531acf01e/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:94c44ee01fd21c9058f124d2d4f0c9dc7634bec93cd4b38eefc385dabe71acbf", size = 560003, upload-time = "2025-08-27T12:16:08.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/f5a344c534214cc2d41118c0699fffbdc2c1bc7046f2a2b9609765ab9c92/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:df8b74962e35c9249425d90144e721eed198e6555a0e22a563d29fe4486b51f6", size = 590482, upload-time = "2025-08-27T12:16:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/08/4349bdd5c64d9d193c360aa9db89adeee6f6682ab8825dca0a3f535f434f/rpds_py-0.27.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:dc23e6820e3b40847e2f4a7726462ba0cf53089512abe9ee16318c366494c17a", size = 556523, upload-time = "2025-08-27T12:16:12.188Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/5463cd5048a7a2fcdae308b6e96432802132c141bfb9420260142632a0f1/rpds_py-0.27.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:aa8933159edc50be265ed22b401125c9eebff3171f570258854dbce3ecd55475", size = 371778, upload-time = "2025-08-27T12:16:13.851Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c8/f38c099db07f5114029c1467649d308543906933eebbc226d4527a5f4693/rpds_py-0.27.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:a50431bf02583e21bf273c71b89d710e7a710ad5e39c725b14e685610555926f", size = 354394, upload-time = "2025-08-27T12:16:15.609Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/b76f97704d9dd8ddbd76fed4c4048153a847c5d6003afe20a6b5c3339065/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78af06ddc7fe5cc0e967085a9115accee665fb912c22a3f54bad70cc65b05fe6", size = 382348, upload-time = "2025-08-27T12:16:17.251Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3f/ef23d3c1be1b837b648a3016d5bbe7cfe711422ad110b4081c0a90ef5a53/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:70d0738ef8fee13c003b100c2fbd667ec4f133468109b3472d249231108283a3", size = 394159, upload-time = "2025-08-27T12:16:19.251Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8a/9e62693af1a34fd28b1a190d463d12407bd7cf561748cb4745845d9548d3/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2f6fd8a1cea5bbe599b6e78a6e5ee08db434fc8ffea51ff201c8765679698b3", size = 522775, upload-time = "2025-08-27T12:16:20.929Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0d/8d5bb122bf7a60976b54c5c99a739a3819f49f02d69df3ea2ca2aff47d5c/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8177002868d1426305bb5de1e138161c2ec9eb2d939be38291d7c431c4712df8", size = 402633, upload-time = "2025-08-27T12:16:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/0e/237948c1f425e23e0cf5a566d702652a6e55c6f8fbd332a1792eb7043daf/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:008b839781d6c9bf3b6a8984d1d8e56f0ec46dc56df61fd669c49b58ae800400", size = 384867, upload-time = "2025-08-27T12:16:24.29Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/0a/da0813efcd998d260cbe876d97f55b0f469ada8ba9cbc47490a132554540/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:a55b9132bb1ade6c734ddd2759c8dc132aa63687d259e725221f106b83a0e485", size = 401791, upload-time = "2025-08-27T12:16:25.954Z" },
+    { url = "https://files.pythonhosted.org/packages/51/78/c6c9e8a8aaca416a6f0d1b6b4a6ee35b88fe2c5401d02235d0a056eceed2/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a46fdec0083a26415f11d5f236b79fa1291c32aaa4a17684d82f7017a1f818b1", size = 419525, upload-time = "2025-08-27T12:16:27.659Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/5af37e1d71487cf6d56dd1420dc7e0c2732c1b6ff612aa7a88374061c0a8/rpds_py-0.27.1-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:8a63b640a7845f2bdd232eb0d0a4a2dd939bcdd6c57e6bb134526487f3160ec5", size = 559255, upload-time = "2025-08-27T12:16:29.343Z" },
+    { url = "https://files.pythonhosted.org/packages/40/7f/8b7b136069ef7ac3960eda25d832639bdb163018a34c960ed042dd1707c8/rpds_py-0.27.1-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:7e32721e5d4922deaaf963469d795d5bde6093207c52fec719bd22e5d1bedbc4", size = 590384, upload-time = "2025-08-27T12:16:31.005Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/06/c316d3f6ff03f43ccb0eba7de61376f8ec4ea850067dddfafe98274ae13c/rpds_py-0.27.1-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:2c426b99a068601b5f4623573df7a7c3d72e87533a2dd2253353a03e7502566c", size = 555959, upload-time = "2025-08-27T12:16:32.73Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/384cf54c430b9dac742bbd2ec26c23feb78ded0d43d6d78563a281aec017/rpds_py-0.27.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:4fc9b7fe29478824361ead6e14e4f5aed570d477e06088826537e202d25fe859", size = 228784, upload-time = "2025-08-27T12:16:34.428Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **Record/replay cassettes** (`db674dd`) — VCR-style hermetic replay for `evalview simulate`. Capture real tool calls once, replay deterministically forever. New flags: `--record`, `--replay`, `--cassette-dir`. Per-tool sequential matching is robust to inter-tool ordering drift.
- **Loud capability check** (`b652b41`, `ad4d6fd`) — `Simulator` now probes adapters for tool/response/http interception seams. Fails fast under `--record` / `--replay` / `mocks.strict=true` instead of silently going live; warns under lenient runs unless `--allow-live` is set. `SimulationResult.adapter_capability` surfaces the truth to JSON/CI consumers.
- **Docs** (`ef952f8`) — README front-page bullet + comparisons table row + record/replay subsection so users land on the feature without digging.
- **Lockfile sync** (`c9dc194`) — `uv.lock` catch-up: 0.5.3 → 0.7.1 plus the new `schedule` extra (croniter); jinja2/jsonschema/tomli into core.

## Test plan
- [x] `pytest` — full suite, 1864 tests passing (17 new cassette tests + 7 capability tests)
- [x] `mypy evalview/` — clean
- [ ] Manual: `evalview simulate --record` against an adapter with `tool_executor`, then `--replay` produces identical trace without hitting live services
- [ ] Manual: `evalview simulate --record` against a server-side adapter (LangGraph Cloud) raises `UninterceptableAdapterError` before any live call
- [ ] Manual: lenient run on uninterceptable adapter logs WARNING; same run with `--allow-live` downgrades to INFO

🤖 Generated with [Claude Code](https://claude.com/claude-code)