### PR TITLE
feat: Add Vercel AI SDK adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ Cassettes live at `.evalview/cassettes/<test>.json`, use per-tool sequential mat
 
 **Decision rationale** — every tool_choice / branch gets recorded with the chosen option, alternatives considered, and any model-reported reasoning (Anthropic `thinking` blocks auto-captured). Grouped across runs by `input_hash` so cloud analytics surfaces decision drift before your users notice. Local HTML replay shows it inline.
 
-Supported adapters: Anthropic, OpenAI Assistants, LangGraph, CrewAI native.
+Supported adapters: Anthropic, OpenAI Assistants, LangGraph, CrewAI native, Vercel AI.
 
 [`docs/SIMULATE.md`](docs/SIMULATE.md) · [`docs/RATIONALE.md`](docs/RATIONALE.md) · [`examples/simulation/`](examples/simulation)
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -143,6 +143,85 @@ If no recognized events are found, the adapter:
 2. Accumulates all text as final output
 3. Still captures timing and basic metrics
 
+---
+
+### Vercel AI Adapter
+
+For Vercel AI SDK agents running on HTTP endpoints.
+
+**Use when:**
+- Your agent uses the Vercel AI SDK
+- You have an HTTP endpoint serving a Vercel AI agent
+- You need to capture streamed responses with tool calls
+
+**Configuration:**
+```yaml
+# .evalview/config.yaml
+adapter: vercel-ai
+endpoint: http://localhost:3000/api/chat
+timeout: 30.0
+headers:
+  Authorization: Bearer your-api-key
+```
+
+**Protocol:**
+
+The Vercel AI adapter parses the Vercel AI SDK streaming protocol where each line is prefixed with a type indicator:
+
+```
+0:"Hello "           # Text chunk
+2:[{"toolName":"search","args":{"query":"Paris"}}]  # Tool calls array
+0:"world"            # More text
+```
+
+| Prefix | Type | Content | Action |
+|--------|------|---------|--------|
+| `0:` | Text | JSON-encoded string | Appends to output |
+| `2:` | Tools | JSON array of tool objects | Creates step traces |
+| Other | Metadata | Ignored | No action |
+
+**Tool Call Format:**
+
+Tool calls are provided as a JSON array with `toolName` and `args` fields:
+
+```json
+[
+  {
+    "toolName": "search",
+    "args": {"query": "Paris"}
+  },
+  {
+    "toolName": "format",
+    "args": {"text": "Paris is the capital"}
+  }
+]
+```
+
+These are automatically mapped to the standard `name` and `arguments` fields.
+
+**Example Request/Response:**
+
+The adapter sends:
+```json
+{
+  "query": "What is the capital of France?",
+  "context": {}
+}
+```
+
+The agent streams back:
+```
+0:"Searching "
+2:[{"toolName":"web_search","args":{"query":"capital of France"}}]
+0:" for the capital..."
+```
+
+**Features:**
+- Streams tool calls as they arrive
+- Accumulates text fragments into final output
+- Handles malformed JSON gracefully (logs warning, continues)
+- Extracts and records all tool calls in trace steps
+
 ## Custom Adapters
 
 Build a custom adapter for your specific agent implementation.

--- a/evalview/adapters/registry.py
+++ b/evalview/adapters/registry.py
@@ -284,6 +284,13 @@ class AdapterRegistry:
         except ImportError:
             logger.warning("AiderAdapter not available")
 
+        try:
+            from evalview.adapters.vercel_ai_adapter import VercelAIAdapter
+
+            cls.register("vercel-ai", VercelAIAdapter)
+        except ImportError:
+            logger.warning("VercelAIAdapter not available")
+
         cls._initialized = True
 
     @classmethod

--- a/evalview/adapters/vercel_ai_adapter.py
+++ b/evalview/adapters/vercel_ai_adapter.py
@@ -16,7 +16,6 @@ from evalview.core.types import (
     StepTrace,
     StepMetrics,
     ExecutionMetrics,
-    TokenUsage,
     SpanKind,
 )
 from evalview.core.tracing import Tracer

--- a/evalview/adapters/vercel_ai_adapter.py
+++ b/evalview/adapters/vercel_ai_adapter.py
@@ -1,0 +1,224 @@
+"""Vercel AI SDK adapter for EvalView.
+
+Supports testing Vercel AI agents by parsing their streaming protocol format.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Set
+import json
+import httpx
+import logging
+
+from evalview.adapters.base import AgentAdapter
+from evalview.adapters.http_adapter import AgentConnectionError
+from evalview.core.types import (
+    ExecutionTrace,
+    StepTrace,
+    StepMetrics,
+    ExecutionMetrics,
+    TokenUsage,
+    SpanKind,
+)
+from evalview.core.tracing import Tracer
+
+logger = logging.getLogger(__name__)
+
+
+class VercelAIAdapter(AgentAdapter):
+    """Adapter for Vercel AI SDK agent endpoints.
+
+    Connects to an HTTP endpoint running a Vercel AI agent and captures
+    streamed responses in the Vercel AI protocol format.
+
+    The adapter parses streaming responses where each line is prefixed with
+    a type indicator:
+    - "0:" for text chunks
+    - "2:" for tool call arrays
+    - Other prefixes are ignored
+
+    Args:
+        endpoint: URL of the Vercel AI agent endpoint
+        headers: Optional HTTP headers (e.g., for authentication)
+        timeout: Request timeout in seconds
+        model_config: Model configuration with name and optional pricing
+        allow_private_urls: Allow requests to private/internal networks
+        allowed_hosts: Set of explicitly allowed hostnames
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        headers: Optional[Dict[str, str]] = None,
+        timeout: float = 30.0,
+        model_config: Optional[Dict[str, Any]] = None,
+        allow_private_urls: bool = False,
+        allowed_hosts: Optional[Set[str]] = None,
+        verbose: bool = False,
+    ):
+        self.allow_private_urls = allow_private_urls
+        self.allowed_hosts = allowed_hosts
+        self.endpoint = self.validate_endpoint(endpoint)
+        self.headers = headers or {}
+        self.timeout = timeout
+        self.model_config = model_config or {}
+        self.verbose = verbose
+
+    @property
+    def name(self) -> str:
+        return "vercel-ai"
+
+    async def execute(self, query: str, context: Optional[Dict[str, Any]] = None) -> ExecutionTrace:
+        """Execute agent via Vercel AI endpoint and capture trace."""
+        start_time = datetime.now()
+        tracer = Tracer()
+
+        final_text = ""
+        tool_calls_list: List[Dict[str, Any]] = []
+
+        try:
+            async with tracer.start_span_async("Vercel AI Agent", SpanKind.AGENT):
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    api_start = datetime.now()
+
+                    response = await client.post(
+                        self.endpoint,
+                        json={
+                            "query": query,
+                            "context": context or {},
+                        },
+                        headers={
+                            "Content-Type": "application/json",
+                            **self.headers,
+                        },
+                    )
+
+                    response.raise_for_status()
+
+                    async for line in response.aiter_lines():
+                        line = line.strip()
+                        if not line:
+                            continue
+
+                        # Parse Vercel AI streaming protocol
+                        if line.startswith("0:"):
+                            # Text chunk
+                            json_str = line[2:]
+                            try:
+                                text_fragment = json.loads(json_str)
+                                final_text += text_fragment
+                            except json.JSONDecodeError:
+                                logger.warning(f"Failed to decode text chunk: {json_str}")
+
+                        elif line.startswith("2:"):
+                            # Tool calls array
+                            json_str = line[2:]
+                            try:
+                                tool_calls_raw = json.loads(json_str)
+                                if isinstance(tool_calls_raw, list):
+                                    for tool_call in tool_calls_raw:
+                                        # Map Vercel field names to standard names
+                                        standardized = {
+                                            "name": tool_call.get("toolName", "unknown"),
+                                            "arguments": tool_call.get("args", {}),
+                                        }
+                                        tool_calls_list.append(standardized)
+                            except json.JSONDecodeError:
+                                logger.warning(f"Failed to decode tool calls: {json_str}")
+
+                        # Ignore other prefixes (1:, 3:, 9:, etc.)
+
+                    api_end = datetime.now()
+                    api_latency = (api_end - api_start).total_seconds() * 1000
+
+        except httpx.ConnectError as e:
+            error_msg = str(e)
+            if "Name or service not known" in error_msg or "nodename nor servname" in error_msg:
+                raise AgentConnectionError(
+                    "DNS resolution failed. Check that the hostname is correct.",
+                    endpoint=self.endpoint,
+                    error_type="dns",
+                ) from None
+            raise AgentConnectionError(
+                "Connection refused. Is your agent running?",
+                endpoint=self.endpoint,
+                error_type="refused",
+            ) from None
+
+        except httpx.TimeoutException:
+            raise AgentConnectionError(
+                f"Request timed out after {self.timeout}s. Try increasing --timeout.",
+                endpoint=self.endpoint,
+                error_type="timeout",
+            ) from None
+
+        except httpx.RemoteProtocolError:
+            raise AgentConnectionError(
+                "Protocol error. Check that the endpoint URL is correct.",
+                endpoint=self.endpoint,
+                error_type="protocol",
+            ) from None
+
+        except httpx.StreamError:
+            raise AgentConnectionError(
+                "Connection closed unexpectedly. Check your network and try again.",
+                endpoint=self.endpoint,
+                error_type="stream",
+            ) from None
+
+        except httpx.HTTPStatusError as e:
+            raise AgentConnectionError(
+                f"HTTP {e.response.status_code}: {e.response.reason_phrase}",
+                endpoint=self.endpoint,
+                error_type="http",
+            ) from None
+
+        # Build steps from tool calls
+        steps: List[StepTrace] = []
+        for idx, tool_call in enumerate(tool_calls_list, 1):
+            steps.append(
+                StepTrace(
+                    step_id=f"step-{idx}",
+                    step_name=f"tool_call_{idx}",
+                    tool_name=tool_call.get("name", "unknown"),
+                    parameters=tool_call.get("arguments", {}),
+                    output=None,
+                    success=True,
+                    metrics=StepMetrics(
+                        latency=api_latency / max(len(tool_calls_list), 1),
+                        cost=0.0,
+                    ),
+                )
+            )
+
+        end_time = datetime.now()
+        total_latency = (end_time - start_time).total_seconds() * 1000
+
+        # Record tool calls in tracer
+        for tool_call in tool_calls_list:
+            tracer.record_tool_call(
+                tool_name=tool_call.get("name", "unknown"),
+                parameters=tool_call.get("arguments", {}),
+                result=None,
+                duration_ms=api_latency / max(len(tool_calls_list), 1),
+            )
+
+        # Create trace
+        trace = ExecutionTrace(
+            session_id=f"session-vercel-{int(start_time.timestamp())}",
+            start_time=start_time,
+            end_time=end_time,
+            steps=steps,
+            final_output=final_text,
+            metrics=ExecutionMetrics(
+                total_cost=0.0,
+                total_latency=total_latency,
+                total_tokens=None,
+            ),
+        )
+
+        trace.trace_context = tracer.build_trace_context()
+
+        if self.verbose:
+            logger.info(f"✓ Vercel AI execution complete: {len(steps)} tool calls, output length {len(final_text)}")
+
+        return trace

--- a/tests/test_vercel_ai_adapter.py
+++ b/tests/test_vercel_ai_adapter.py
@@ -1,0 +1,358 @@
+"""Tests for Vercel AI adapter."""
+
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+import httpx
+
+from evalview.adapters.vercel_ai_adapter import VercelAIAdapter
+from evalview.core.types import ExecutionTrace
+
+
+def async_iter(items):
+    """Helper to create async iterator function."""
+    async def _iter():
+        for item in items:
+            yield item
+    return _iter()
+
+
+class MockStreamResponse:
+    """Mock response with streaming support."""
+    def __init__(self, stream_lines):
+        self.stream_lines = stream_lines
+
+    def aiter_lines(self):
+        """Return async iterator for lines."""
+        return async_iter(self.stream_lines)
+
+    def raise_for_status(self):
+        """Simulate status check."""
+        pass
+
+
+class TestVercelAIAdapter:
+    """Tests for VercelAIAdapter streaming and tool call parsing."""
+
+    @pytest.mark.asyncio
+    async def test_execute_basic(self):
+        """Test basic execution with simple text response."""
+        adapter = VercelAIAdapter(endpoint="http://test.com/api")
+
+        stream_lines = [
+            '0:"Hello "',
+            '0:"world"',
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MockStreamResponse(stream_lines)
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            trace = await adapter.execute("test query")
+
+            assert isinstance(trace, ExecutionTrace)
+            assert trace.final_output == "Hello world"
+            assert len(trace.steps) == 0
+            mock_client.post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_with_tool_calls(self):
+        """Test execution with tool calls."""
+        adapter = VercelAIAdapter(endpoint="http://test.com/api")
+
+        stream_lines = [
+            '0:"Searching for "',
+            '2:[{"toolName":"search","args":{"query":"Paris"}}]',
+            '0:"the capital"',
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MockStreamResponse(stream_lines)
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            trace = await adapter.execute("What is the capital of France?")
+
+            assert isinstance(trace, ExecutionTrace)
+            assert trace.final_output == "Searching for the capital"
+            assert len(trace.steps) == 1
+            assert trace.steps[0].tool_name == "search"
+            assert trace.steps[0].parameters == {"query": "Paris"}
+            assert trace.steps[0].step_name == "tool_call_1"
+
+    @pytest.mark.asyncio
+    async def test_execute_with_multiple_tool_calls(self):
+        """Test execution with multiple sequential tool calls."""
+        adapter = VercelAIAdapter(endpoint="http://test.com/api")
+
+        stream_lines = [
+            '0:"Searching "',
+            '2:[{"toolName":"search","args":{"query":"Paris"}}]',
+            '0:" and "',
+            '2:[{"toolName":"format","args":{"text":"Paris is capital"}}]',
+            '0:"done"',
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MockStreamResponse(stream_lines)
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            trace = await adapter.execute("What is the capital of France?")
+
+            assert trace.final_output == "Searching  and done"
+            assert len(trace.steps) == 2
+            assert trace.steps[0].tool_name == "search"
+            assert trace.steps[1].tool_name == "format"
+
+    @pytest.mark.asyncio
+    async def test_execute_with_array_of_tool_calls(self):
+        """Test execution with array of tool calls in one message."""
+        adapter = VercelAIAdapter(endpoint="http://test.com/api")
+
+        stream_lines = [
+            '0:"Processing "',
+            '2:[{"toolName":"tool1","args":{"a":"1"}},{"toolName":"tool2","args":{"b":"2"}}]',
+            '0:"complete"',
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MockStreamResponse(stream_lines)
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            trace = await adapter.execute("test")
+
+            assert trace.final_output == "Processing complete"
+            assert len(trace.steps) == 2
+            assert trace.steps[0].tool_name == "tool1"
+            assert trace.steps[0].parameters == {"a": "1"}
+            assert trace.steps[1].tool_name == "tool2"
+            assert trace.steps[1].parameters == {"b": "2"}
+
+    @pytest.mark.asyncio
+    async def test_execute_ignores_unknown_prefixes(self):
+        """Test that unknown message prefixes are ignored."""
+        adapter = VercelAIAdapter(endpoint="http://test.com/api")
+
+        stream_lines = [
+            '0:"Hello"',
+            '1:{"type":"metadata"}',
+            '3:{"other":"data"}',
+            '0:" world"',
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MockStreamResponse(stream_lines)
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            trace = await adapter.execute("test")
+
+            assert trace.final_output == "Hello world"
+            assert len(trace.steps) == 0
+
+    @pytest.mark.asyncio
+    async def test_execute_empty_lines_ignored(self):
+        """Test that empty lines are properly ignored."""
+        adapter = VercelAIAdapter(endpoint="http://test.com/api")
+
+        stream_lines = [
+            '0:"Part1"',
+            "",
+            "   ",
+            '0:"Part2"',
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MockStreamResponse(stream_lines)
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            trace = await adapter.execute("test")
+
+            assert trace.final_output == "Part1Part2"
+
+    @pytest.mark.asyncio
+    async def test_execute_malformed_json_ignored(self):
+        """Test that malformed JSON is handled gracefully."""
+        adapter = VercelAIAdapter(endpoint="http://test.com/api", verbose=True)
+
+        stream_lines = [
+            '0:"Start"',
+            '0:"{invalid json"',
+            '0:" End"',
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MockStreamResponse(stream_lines)
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            trace = await adapter.execute("test")
+
+            assert "Start" in trace.final_output
+            assert "End" in trace.final_output
+
+    @pytest.mark.asyncio
+    async def test_adapter_name(self):
+        """Test that adapter returns correct name."""
+        adapter = VercelAIAdapter(endpoint="http://test.com/api")
+        assert adapter.name == "vercel-ai"
+
+    @pytest.mark.asyncio
+    async def test_execute_connection_error(self):
+        """Test handling of connection errors."""
+        adapter = VercelAIAdapter(endpoint="http://test.com/api")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = httpx.ConnectError("Connection refused")
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            with pytest.raises(Exception) as exc_info:
+                await adapter.execute("test")
+
+            assert "Connection" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_execute_timeout_error(self):
+        """Test handling of timeout errors."""
+        adapter = VercelAIAdapter(endpoint="http://test.com/api", timeout=5.0)
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = httpx.TimeoutException("Timeout")
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            with pytest.raises(Exception) as exc_info:
+                await adapter.execute("test")
+
+            assert "timeout" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_execute_with_headers(self):
+        """Test that custom headers are sent."""
+        headers = {"Authorization": "Bearer token123"}
+        adapter = VercelAIAdapter(
+            endpoint="http://test.com/api",
+            headers=headers,
+        )
+
+        stream_lines = ['0:"response"']
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MockStreamResponse(stream_lines)
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            trace = await adapter.execute("test")
+
+            call_kwargs = mock_client.post.call_args.kwargs
+            assert "Authorization" in call_kwargs["headers"]
+            assert call_kwargs["headers"]["Authorization"] == "Bearer token123"
+
+    @pytest.mark.asyncio
+    async def test_execute_with_context(self):
+        """Test that context is sent in the request."""
+        adapter = VercelAIAdapter(endpoint="http://test.com/api")
+
+        stream_lines = ['0:"response"']
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MockStreamResponse(stream_lines)
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            context = {"user_id": "123", "session": "abc"}
+            trace = await adapter.execute("test query", context=context)
+
+            call_args = mock_client.post.call_args
+            assert call_args.kwargs["json"]["context"] == context
+
+    @pytest.mark.asyncio
+    async def test_trace_structure(self):
+        """Test that the returned trace has all required fields."""
+        adapter = VercelAIAdapter(endpoint="http://test.com/api")
+
+        stream_lines = [
+            '0:"Hello "',
+            '2:[{"toolName":"greet","args":{"name":"World"}}]',
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MockStreamResponse(stream_lines)
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            trace = await adapter.execute("test")
+
+            assert trace.session_id
+            assert trace.start_time
+            assert trace.end_time
+            assert trace.final_output == "Hello "
+            assert trace.metrics
+            assert trace.metrics.total_latency >= 0
+            assert trace.metrics.total_cost >= 0
+            assert len(trace.steps) == 1
+            assert trace.steps[0].step_id == "step-1"
+            assert trace.steps[0].success is True
+
+    @pytest.mark.asyncio
+    async def test_tool_call_mapping(self):
+        """Test that Vercel tool names are correctly mapped."""
+        adapter = VercelAIAdapter(endpoint="http://test.com/api")
+
+        stream_lines = [
+            '2:[{"toolName":"my_custom_tool","args":{"param1":"value1","param2":123}}]',
+        ]
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MockStreamResponse(stream_lines)
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            trace = await adapter.execute("test")
+
+            step = trace.steps[0]
+            assert step.tool_name == "my_custom_tool"
+            assert step.parameters["param1"] == "value1"
+            assert step.parameters["param2"] == 123

--- a/tests/test_vercel_ai_adapter.py
+++ b/tests/test_vercel_ai_adapter.py
@@ -1,8 +1,7 @@
 """Tests for Vercel AI adapter."""
 
 import pytest
-from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 import httpx
 
 from evalview.adapters.vercel_ai_adapter import VercelAIAdapter
@@ -275,7 +274,7 @@ class TestVercelAIAdapter:
             mock_client.__aexit__.return_value = None
             mock_client_class.return_value = mock_client
 
-            trace = await adapter.execute("test")
+            await adapter.execute("test")
 
             call_kwargs = mock_client.post.call_args.kwargs
             assert "Authorization" in call_kwargs["headers"]
@@ -297,7 +296,7 @@ class TestVercelAIAdapter:
             mock_client_class.return_value = mock_client
 
             context = {"user_id": "123", "session": "abc"}
-            trace = await adapter.execute("test query", context=context)
+            await adapter.execute("test query", context=context)
 
             call_args = mock_client.post.call_args
             assert call_args.kwargs["json"]["context"] == context


### PR DESCRIPTION
Implemented Vercel AI SDK adapter that enables testing of Vercel AI agent endpoints by parsing their line-delimited streaming protocol format, extracting conversational text and tool calls based on message prefixes, and returning the data in the standard ExecutionTrace format.

## Related Issue

Fixes #239 

## Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update

## Changes Made

<!-- Provide a detailed list of changes -->

- Added vercel_ai_adapter.py - VercelAIAdapter class with streaming protocol parsing
- Registered adapter in registry.py with try/except pattern
- Updated ADAPTERS.md with Vercel AI section including protocol explanation and examples
- Updated README.md adapter list to include "Vercel AI"

## Testing

### Test Configuration

- **Python Version**: 3.13.7
- **OS**: Windows 11

### Tests Added/Modified

- [X] Integration tests added/updated
- [X] All tests pass locally
- [X] Test coverage maintained or improved

### Manual Testing Steps

```
# Run the test suite
py -m pytest tests/test_vercel_ai_adapter.py -v
```

## Checklist

### Code Quality

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code

### Documentation

- [X] I have updated the documentation (ADAPTERS.md and README.md)
- [X] I have added docstrings to new functions/classes

### Testing

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

### Dependencies

- [X] I have checked that no new dependencies were added unnecessarily

## Screenshots

<img width="1567" height="875" alt="evalview4" src="https://github.com/user-attachments/assets/d888da64-58c8-4dca-83d1-be5d3248aeb7" />

## Reviewer Notes

- Protocol Parsing - Verify if my parsing approach is correct (prefix 0: for text, 2: for tool calls as JSON array with toolName/args fields)

---

**By submitting this pull request, I confirm that:**

- [X] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [X] I agree to the project's [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [X] My contribution is my own work and I have the right to contribute it
